### PR TITLE
Fix deprecated Cloud Run egress setting

### DIFF
--- a/cloudrun_vpc_access_connector/main.tf
+++ b/cloudrun_vpc_access_connector/main.tf
@@ -72,7 +72,7 @@ resource "google_cloud_run_service" "gcr_service" {
         # Use the VPC Connector
         "run.googleapis.com/vpc-access-connector" = google_vpc_access_connector.connector.name
         # all egress from the service should go through the VPC Connector
-        "run.googleapis.com/vpc-access-egress" = "all"
+        "run.googleapis.com/vpc-access-egress" = "all-traffic"
       }
     }
   }


### PR DESCRIPTION
The Cloud Run annotation value "all" for the "run.googleapis.com/vpc-access-egress" annotation is deprecated. The replacement value is "all-traffic". The docs samples should use the new "all-traffic" value.

See the Cloud Run API documentation for details: https://cloud.google.com/run/docs/reference/rest/v1/RevisionTemplate.