### PR TITLE
Fix/cloudrun pubsub

### DIFF
--- a/cloud_run_service_pubsub/main.tf
+++ b/cloud_run_service_pubsub/main.tf
@@ -33,9 +33,13 @@ resource "google_cloud_run_service_iam_binding" "binding" {
 # [END cloudrun_service_pubsub_run_invoke_permissions]
 
 # [START cloudrun_service_pubsub_token_permissions]
-resource "google_project_iam_binding" "project" {
+
+data "google_project" "project" {
+}
+  
+resource "google_project_iam_binding" "project_token_creator" {
   role    = "roles/iam.serviceAccountTokenCreator"
-  members = ["serviceAccount:${google_service_account.sa.email}"]
+  members = [ "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"]
 }
 # [END cloudrun_service_pubsub_token_permissions]
 

--- a/cloud_run_service_pubsub/main.tf
+++ b/cloud_run_service_pubsub/main.tf
@@ -1,18 +1,18 @@
 # [START cloudrun_service_pubsub_service]
 resource "google_cloud_run_service" "default" {
-    name     = "cloud_run_service_name"
-    location = "us-central1"
-    template {
-      spec {
-            containers {
-                image = "gcr.io/cloudrun/hello"
-            }
+  name     = "cloud_run_service_name"
+  location = "us-central1"
+  template {
+    spec {
+      containers {
+        image = "gcr.io/cloudrun/hello"
       }
     }
-    traffic {
-      percent         = 100
-      latest_revision = true
-    }
+  }
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
 }
 # [END cloudrun_service_pubsub_service]
 
@@ -26,9 +26,9 @@ resource "google_service_account" "sa" {
 # [START cloudrun_service_pubsub_run_invoke_permissions]
 resource "google_cloud_run_service_iam_binding" "binding" {
   location = google_cloud_run_service.default.location
-  service = google_cloud_run_service.default.name
-  role = "roles/run.invoker"
-  members = ["serviceAccount:${google_service_account.sa.email}"]
+  service  = google_cloud_run_service.default.name
+  role     = "roles/run.invoker"
+  members  = ["serviceAccount:${google_service_account.sa.email}"]
 }
 # [END cloudrun_service_pubsub_run_invoke_permissions]
 
@@ -36,10 +36,10 @@ resource "google_cloud_run_service_iam_binding" "binding" {
 
 data "google_project" "project" {
 }
-  
+
 resource "google_project_iam_binding" "project_token_creator" {
   role    = "roles/iam.serviceAccountTokenCreator"
-  members = [ "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"]
+  members = ["serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"]
 }
 # [END cloudrun_service_pubsub_token_permissions]
 

--- a/cloud_run_service_pubsub/main.tf
+++ b/cloud_run_service_pubsub/main.tf
@@ -37,9 +37,15 @@ resource "google_cloud_run_service_iam_binding" "binding" {
 data "google_project" "project" {
 }
 
+resource "google_project_service_identity" "pubsub_agent" {
+  provider = google-beta
+  project  = data.google_project.project.project_id
+  service  = "pubsub.googleapis.com"
+}
+
 resource "google_project_iam_binding" "project_token_creator" {
   role    = "roles/iam.serviceAccountTokenCreator"
-  members = ["serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"]
+  members = ["serviceAccount:${google_project_service_identity.pubsub_agent.email}"]
 }
 # [END cloudrun_service_pubsub_token_permissions]
 


### PR DESCRIPTION
This PR fixes an error in the cloud_run_service_pubsub `main.tf` used in https://cloud.google.com/run/docs/triggering/pubsub-push#terraform_1

The serviceAccountTokenCreator role should be granted to the pubservice agent instead of the user-created service account.  