### PR TITLE
chore: parallel tests

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -45,7 +45,6 @@ steps:
   dir: test/integration
   waitFor:
     - prepare
-
 tags:
 - 'ci'
 - 'integration'

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -39,6 +39,12 @@ steps:
   dir: test/integration
   waitFor:
     - prepare
+- id: test-samples-3
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'go test -v -timeout 0 -run TestSamples/3']
+  dir: test/integration
+  waitFor:
+    - prepare
 
 tags:
 - 'ci'

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -21,10 +21,25 @@ steps:
   - 'TF_VAR_org_id=$_ORG_ID'
   - 'TF_VAR_folder_id=$_FOLDER_ID'
   - 'TF_VAR_billing_account=$_BILLING_ACCOUNT'
-- id: test-all-samples
+- id: test-samples-0
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'go test -v -timeout 0']
+  args: ['/bin/bash', '-c', 'go test -v -timeout 0 -run TestSamples/0']
   dir: test/integration
+  waitFor:
+    - prepare
+- id: test-samples-1
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'go test -v -timeout 0 -run TestSamples/1']
+  dir: test/integration
+  waitFor:
+    - prepare
+- id: test-samples-2
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'go test -v -timeout 0 -run TestSamples/2']
+  dir: test/integration
+  waitFor:
+    - prepare
+
 tags:
 - 'ci'
 - 'integration'

--- a/cloud_run_service_custom_domain_mapping/test.yaml
+++ b/cloud_run_service_custom_domain_mapping/test.yaml
@@ -1,0 +1,20 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintTest
+metadata:
+  name: cloud_run_service_custom_domain_mapping
+spec:
+  skip: true

--- a/regional_external_http_load_balancer/main.tf
+++ b/regional_external_http_load_balancer/main.tf
@@ -92,7 +92,6 @@ resource "google_compute_instance_template" "default" {
     }
     network            = google_compute_network.default.id
     subnetwork         = google_compute_subnetwork.default.id
-    subnetwork_project = "load-balancer-https"
   }
   region = "us-west1"
   scheduling {
@@ -189,7 +188,7 @@ resource "google_compute_forwarding_rule" "default" {
   name                  = "l7-xlb-forwarding-rule"
   provider              = google-beta
   depends_on            = [google_compute_subnetwork.proxy_only]
-  region                = "us-east1"
+  region                = "us-west1"
 
   ip_protocol           = "TCP"
   load_balancing_scheme = "EXTERNAL_MANAGED"

--- a/test/integration/sample_test.go
+++ b/test/integration/sample_test.go
@@ -3,7 +3,6 @@ package samples_test
 import (
 	"fmt"
 	"io/ioutil"
-	"math"
 	"path"
 	"sort"
 	"testing"
@@ -72,7 +71,7 @@ var skipDiscoverDirs = map[string]bool{
 
 // discoverTestCaseGroups discovers individual sample directories in the parent directory.
 // It also skips known directories that are not samples.
-func discoverTestCaseGroups(t *testing.T, projects []string) []testGroups {
+func discoverTestCaseGroups(t *testing.T, projects []string) []*testGroups {
 	t.Helper()
 	samples := []string{}
 	dirs, err := ioutil.ReadDir(sampleDir)
@@ -89,17 +88,13 @@ func discoverTestCaseGroups(t *testing.T, projects []string) []testGroups {
 	sampleLen := len(samples)
 	t.Logf("discovered %d samples", sampleLen)
 
-	tcs := []testGroups{}
-	chunkSize := int(math.Ceil(float64(sampleLen) / float64(len(projects))))
-	t.Logf("using chunk size %d", sampleLen)
-	start := 0
+	tcs := []*testGroups{}
 	for i, project := range projects {
-		end := start + chunkSize
-		if end > sampleLen {
-			end = sampleLen
-		}
-		tcs = append(tcs, testGroups{projectID: project, samples: samples[start:end], group: i})
-		start = end
+		tcs = append(tcs, &testGroups{projectID: project, samples: []string{}, group: i})
+	}
+	for i, sample := range samples {
+		idx := i % len(projects)
+		tcs[idx].samples = append(tcs[idx].samples, sample)
 	}
 	return tcs
 }

--- a/test/integration/sample_test.go
+++ b/test/integration/sample_test.go
@@ -100,8 +100,8 @@ func discoverTestCaseGroups(t *testing.T, projects []string) []*testGroups {
 	// Chunking would result in all sql* assigned to a single project.
 	// We sort the sample slice beforehand so assignments should be stable for a given run.
 	for i, sample := range samples {
-		idx := i % len(projects)
-		groups[idx].samples = append(groups[idx].samples, sample)
+		groupIndex := i % len(projects)
+		groups[groupIndex].samples = append(groups[groupIndex].samples, sample)
 	}
 	return groups
 }

--- a/test/integration/sample_test.go
+++ b/test/integration/sample_test.go
@@ -1,8 +1,11 @@
 package samples_test
 
 import (
+	"fmt"
 	"io/ioutil"
+	"math"
 	"path"
+	"sort"
 	"testing"
 	"time"
 
@@ -14,6 +17,12 @@ const (
 	setupPath = "../setup"
 	sampleDir = "../../"
 )
+
+type testGroups struct {
+	projectID string
+	group     int
+	samples   []string
+}
 
 // Retry if these errors are encountered.
 var retryErrors = map[string]string{
@@ -28,26 +37,29 @@ func TestSamples(t *testing.T) {
 		tft.WithTFDir(sampleDir),
 		tft.WithSetupPath(setupPath),
 	)
-	testProjectID := setup.GetTFSetupStringOutput("project_id")
+	testProjectIDs := setup.GetTFSetupOutputListVal("project_ids")
 	testEnv := map[string]string{
-		"GOOGLE_PROJECT": testProjectID,
-		"GOOGLE_REGION":  "us-central1",
-		"GOOGLE_ZONE":    "us-central1-a",
+		"GOOGLE_REGION": "us-central1",
+		"GOOGLE_ZONE":   "us-central1-a",
 	}
 	for k, v := range testEnv {
 		utils.SetEnv(t, k, v)
 	}
 
-	testCases := discoverTestCases(t)
-	for _, tc := range testCases {
-		t.Run(tc, func(t *testing.T) {
-			sampleTest := tft.NewTFBlueprintTest(t,
-				tft.WithTFDir(path.Join(sampleDir, tc)),
-				tft.WithSetupPath(setupPath),
-				tft.WithRetryableTerraformErrors(retryErrors, 10, time.Minute),
-			)
-			sampleTest.Test()
-		})
+	testGroups := discoverTestCaseGroups(t, testProjectIDs)
+	for _, tg := range testGroups {
+		for _, sample := range tg.samples {
+			testName := fmt.Sprintf("%d/%s", tg.group, sample)
+			t.Run(testName, func(t *testing.T) {
+				utils.SetEnv(t, "GOOGLE_PROJECT", tg.projectID)
+				sampleTest := tft.NewTFBlueprintTest(t,
+					tft.WithTFDir(path.Join(sampleDir, sample)),
+					tft.WithSetupPath(setupPath),
+					tft.WithRetryableTerraformErrors(retryErrors, 10, time.Minute),
+				)
+				sampleTest.Test()
+			})
+		}
 	}
 }
 
@@ -58,20 +70,36 @@ var skipDiscoverDirs = map[string]bool{
 	".git":  true,
 }
 
-// discoverTestCases discovers individual sample directories in the parent directory.
+// discoverTestCaseGroups discovers individual sample directories in the parent directory.
 // It also skips known directories that are not samples.
-func discoverTestCases(t *testing.T) []string {
+func discoverTestCaseGroups(t *testing.T, projects []string) []testGroups {
 	t.Helper()
-	tc := []string{}
-	samples, err := ioutil.ReadDir(sampleDir)
+	samples := []string{}
+	dirs, err := ioutil.ReadDir(sampleDir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, f := range samples {
+	for _, f := range dirs {
 		if !f.IsDir() || skipDiscoverDirs[f.Name()] {
 			continue
 		}
-		tc = append(tc, f.Name())
+		samples = append(samples, f.Name())
 	}
-	return tc
+	sort.Strings(samples)
+	sampleLen := len(samples)
+	t.Logf("discovered %d samples", sampleLen)
+
+	tcs := []testGroups{}
+	chunkSize := int(math.Ceil(float64(sampleLen) / float64(len(projects))))
+	t.Logf("using chunk size %d", sampleLen)
+	start := 0
+	for i, project := range projects {
+		end := start + chunkSize
+		if end > sampleLen {
+			end = sampleLen
+		}
+		tcs = append(tcs, testGroups{projectID: project, samples: samples[start:end], group: i})
+		start = end
+	}
+	return tcs
 }

--- a/test/setup/fixtures.tf
+++ b/test/setup/fixtures.tf
@@ -16,7 +16,9 @@
 
 # ca pool to use in privateca samples
 resource "google_privateca_ca_pool" "default" {
-  project  = module.project.project_id
+  count = local.num_projects
+
+  project  = local.project_ids[count.index]
   name     = "my-pool"
   location = "us-central1"
   tier     = "ENTERPRISE"

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -14,23 +14,17 @@
  * limitations under the License.
  */
 
-locals {
-  int_required_roles = [
-    "roles/owner",
-  ]
-}
-
 resource "google_service_account" "int_test" {
-  project      = module.project.project_id
+  project      = module.projects[0].project_id
   account_id   = "ci-account"
   display_name = "ci-account"
 }
 
 resource "google_project_iam_member" "int_test" {
-  count = length(local.int_required_roles)
+  count = local.num_projects
 
-  project = module.project.project_id
-  role    = local.int_required_roles[count.index]
+  project = local.project_ids[count.index]
+  role    = "roles/owner"
   member  = "serviceAccount:${google_service_account.int_test.email}"
 }
 

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 
-module "project" {
+locals {
+  num_projects = 3
+  project_ids = module.projects.*.project_id
+}
+
+module "projects" {
+  count = local.num_projects
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 13.0"
 
-  name                    = "ci-tf-samples"
+  name                    = "ci-tf-samples-${count.index}"
   random_project_id       = true
   org_id                  = var.org_id
   folder_id               = var.folder_id

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -15,7 +15,7 @@
  */
 
 locals {
-  num_projects = 3
+  num_projects = 4
   project_ids = module.projects.*.project_id
 }
 

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -15,6 +15,9 @@
  */
 
 locals {
+  // Sample testing is run in parallel across num_projects.
+  // Discovery and test grouping is dynamic, only this number has to be increased
+  // and build/int.cloudbuild.yaml updated for new test group.
   num_projects = 4
   project_ids = module.projects.*.project_id
 }

--- a/test/setup/outputs.tf
+++ b/test/setup/outputs.tf
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-output "project_id" {
-  value = module.project.project_id
+output "project_ids" {
+  value = local.project_ids
 }
 
 output "sa_key" {


### PR DESCRIPTION
This introduces parallelization when running tests in CI. Sample tests are grouped in to n test groups based [on num projects](https://github.com/terraform-google-modules/terraform-docs-samples/blob/60fbf0ed06e40b5d7e9d3ef3bc0cf069caddf64a/test/setup/main.tf#L18-L21) in setup. I added 4 projects to start with and has resulted in a test time reduction from ~62.5%  (from 4h to 1:30h). 

Test grouping is dynamic and increasing number of projects in the future to reduce time would be a trivial change.