### PR TITLE
Update main.tf

### DIFF
--- a/cloud_run_service_pubsub/main.tf
+++ b/cloud_run_service_pubsub/main.tf
@@ -1,6 +1,6 @@
 # [START cloudrun_service_pubsub_service]
 resource "google_cloud_run_service" "default" {
-    name     = "cloud_run_service_name"
+    name     = "cloud-run-service-name"
     location = "us-central1"
     template {
       spec {
@@ -34,6 +34,7 @@ resource "google_cloud_run_service_iam_binding" "binding" {
 
 # [START cloudrun_service_pubsub_token_permissions]
 resource "google_project_iam_binding" "project" {
+  project = "PROJECT_ID"  # project - (Required) The project id of the target project. This is not inferred from the provider.
   role    = "roles/iam.serviceAccountTokenCreator"
   members = ["serviceAccount:${google_service_account.sa.email}"]
 }


### PR DESCRIPTION
project - (Required) The project id of the target project. This is not inferred from the provider. https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam#project Cloud run service name change--Resource name must use only lowercase letters, numbers and '-'. Must begin with a letter and cannot end with a '-'. Maximum length is 63 characters