### PR TITLE
removing sudo before the name of the vm_hostname variable

### DIFF
--- a/regional_external_http_load_balancer/main.tf
+++ b/regional_external_http_load_balancer/main.tf
@@ -84,7 +84,7 @@ resource "google_compute_instance_template" "default" {
   }
   machine_type = "n1-standard-1"
   metadata = {
-    startup-script = "#! /bin/bash\nsudo apt-get update\nsudo apt-get install apache2 -y\nsudo a2ensite default-ssl\nsudo a2enmod ssl\nsudo vm_hostname=\"$(curl -H \"Metadata-Flavor:Google\" \\\nhttp://169.254.169.254/computeMetadata/v1/instance/name)\"\nsudo echo \"Page served from: $vm_hostname\" | \\\ntee /var/www/html/index.html\nsudo systemctl restart apache2"
+    startup-script = "#! /bin/bash\nsudo apt-get update\nsudo apt-get install apache2 -y\nsudo a2ensite default-ssl\nsudo a2enmod ssl\nvm_hostname=\"$(curl -H \"Metadata-Flavor:Google\" \\\nhttp://169.254.169.254/computeMetadata/v1/instance/name)\"\nsudo echo \"Page served from: $vm_hostname\" | \\\ntee /var/www/html/index.html\nsudo systemctl restart apache2"
   }
   network_interface {
     access_config {

--- a/regional_external_http_load_balancer/main.tf
+++ b/regional_external_http_load_balancer/main.tf
@@ -84,7 +84,18 @@ resource "google_compute_instance_template" "default" {
   }
   machine_type = "n1-standard-1"
   metadata = {
-    startup-script = "#! /bin/bash\nsudo apt-get update\nsudo apt-get install apache2 -y\nsudo a2ensite default-ssl\nsudo a2enmod ssl\nvm_hostname=\"$(curl -H \"Metadata-Flavor:Google\" \\\nhttp://169.254.169.254/computeMetadata/v1/instance/name)\"\nsudo echo \"Page served from: $vm_hostname\" | \\\ntee /var/www/html/index.html\nsudo systemctl restart apache2"
+    startup-script = <<EOF
+    #! /bin/bash
+    sudo apt-get update
+    sudo apt-get install apache2 -y
+    sudo a2ensite default-ssl
+    sudo a2enmod ssl
+    vm_hostname="$(curl -H "Metadata-Flavor:Google" \
+    http://169.254.169.254/computeMetadata/v1/instance/name)"
+    sudo echo "Page served from: $vm_hostname" | \
+    tee /var/www/html/index.html
+    sudo systemctl restart apache2
+    EOF
   }
   network_interface {
     access_config {


### PR DESCRIPTION
Dear team,

In the startup script defined in the creation of an instance template, the name of the instance is not getting captured in the variable `host_name`:
![image](https://user-images.githubusercontent.com/85990631/190371606-51b8e184-ce39-4645-a530-988c25bd503f.png)

Updating the startup script (for the VMs) for different load balancers to remove `sudo` before the variable `vm_hostname`. This allows the name of the instance to get captured correctly:
![image](https://user-images.githubusercontent.com/85990631/190371658-8f64f7bf-a9b9-4796-ae1d-19092cd75597.png)


http://b/246878070