### PR TITLE
remove sudo in vm_hostname vm startup script

### DIFF
--- a/external_http_lb_mig_backend/main.tf
+++ b/external_http_lb_mig_backend/main.tf
@@ -16,7 +16,7 @@ resource "google_compute_instance_template" "default" {
   }
   machine_type = "n1-standard-1"
   metadata = {
-    startup-script = "#! /bin/bash\n     sudo apt-get update\n     sudo apt-get install apache2 -y\n     sudo a2ensite default-ssl\n     sudo a2enmod ssl\n     sudo vm_hostname=\"$(curl -H \"Metadata-Flavor:Google\" \\\n   http://169.254.169.254/computeMetadata/v1/instance/name)\"\n   sudo echo \"Page served from: $vm_hostname\" | \\\n   tee /var/www/html/index.html\n   sudo systemctl restart apache2"
+    startup-script = "#! /bin/bash\n     sudo apt-get update\n     sudo apt-get install apache2 -y\n     sudo a2ensite default-ssl\n     sudo a2enmod ssl\n     vm_hostname=\"$(curl -H \"Metadata-Flavor:Google\" \\\n   http://169.254.169.254/computeMetadata/v1/instance/name)\"\n   sudo echo \"Page served from: $vm_hostname\" | \\\n   tee /var/www/html/index.html\n   sudo systemctl restart apache2"
   }
   network_interface {
     access_config {


### PR DESCRIPTION
In instance template, remove "sudo" in vm_hostname startup script as using sudo was not setting vm_hostname variable during startup. No need to use "sudo" while setting variable.