### PR TITLE
feat(cloudrun): Add Image Processing sample

### DIFF
--- a/cloud_run_service_image_processing/main.tf
+++ b/cloud_run_service_image_processing/main.tf
@@ -1,7 +1,6 @@
 # [START cloudrun_service_image_processing_datasources]
 data "google_project" "project" {}
 
-data "google_storage_project_service_account" "gcs_account" {}
 # [END cloudrun_service_image_processing_datasources]
 
 # [START cloudrun_service_image_processing_inputbucket]
@@ -38,6 +37,8 @@ resource "google_project_iam_member" "output_writer" {
 resource "google_pubsub_topic" "imageproc" {
   name = "imageproc-topic"
 }
+# [START cloudrun_service_image_processing_notifications] 
+data "google_storage_project_service_account" "gcs_account" {}
 
 resource "google_pubsub_topic_iam_binding" "binding" {
   topic   = google_pubsub_topic.imageproc.name
@@ -45,7 +46,6 @@ resource "google_pubsub_topic_iam_binding" "binding" {
   members = ["serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"]
 }
 
-# Configure GCS notifications to pubsub
 resource "google_storage_notification" "notification" {
   provider       = google
   bucket         = google_storage_bucket.imageproc_input.name
@@ -53,6 +53,7 @@ resource "google_storage_notification" "notification" {
   topic          = google_pubsub_topic.imageproc.id
   depends_on     = [google_pubsub_topic_iam_binding.binding]
 }
+# [END cloudrun_service_image_processing_notifications]
 
 # Service Account for delivering messages from pubsub to cloud run
 resource "google_service_account" "delivery_account" {

--- a/cloud_run_service_image_processing/main.tf
+++ b/cloud_run_service_image_processing/main.tf
@@ -21,7 +21,7 @@ resource "google_project_service_identity" "pubsub_agent" {
 }
 
 resource "google_project_iam_binding" "project_token_creator" {
-  project  = data.google_project.project.project_id
+  project = data.google_project.project.project_id
   role    = "roles/iam.serviceAccountTokenCreator"
   members = ["serviceAccount:${google_project_service_identity.pubsub_agent.email}"]
 }

--- a/cloud_run_service_image_processing/main.tf
+++ b/cloud_run_service_image_processing/main.tf
@@ -3,35 +3,21 @@ data "google_project" "project" {}
 
 # [END cloudrun_service_image_processing_datasources]
 
-# [START cloudrun_service_image_processing_inputbucket]
-# Input Bucket
+# [START cloudrun_service_image_processing_buckets]
+resource "random_id" "bucket_prefix" {
+  byte_length = 8
+}
+
 resource "google_storage_bucket" "imageproc_input" {
-  name     = "imageproc-input-bucket"
+  name     = "${random_id.bucket_prefix.hex}-input-bucket"
   location = "us-central1"
 }
 
-# IAM: ensure we can read from the input bucket
-resource "google_project_iam_member" "input_reader" {
-  project = data.google_project.project.project_id
-  member  = "serviceAccount:${google_cloud_run_service.imageproc.template[0].spec[0].service_account_name}"
-  role    = "roles/storage.objectViewer"
-}
-# [END cloudrun_service_image_processing_inputbucket]
-
-# [START cloudrun_service_image_processing_outputbucket]
-# Output Bucket
 resource "google_storage_bucket" "imageproc_output" {
-  name     = "imageproc-output-bucket"
+  name     = "${random_id.bucket_prefix.hex}-output-bucket"
   location = "us-central1"
 }
-
-# IAM: Ensure we can write to the output bucket
-resource "google_project_iam_member" "output_writer" {
-  project = data.google_project.project.project_id
-  member  = "serviceAccount:${google_cloud_run_service.imageproc.template[0].spec[0].service_account_name}"
-  role    = "roles/storage.objectCreator"
-}
-# [END cloudrun_service_image_processing_outputbucket]
+# [END cloudrun_service_image_processing_buckets]
 
 # [START cloudrun_service_image_processing_pubsub]
 resource "google_pubsub_topic" "imageproc" {

--- a/cloud_run_service_image_processing/main.tf
+++ b/cloud_run_service_image_processing/main.tf
@@ -1,6 +1,3 @@
-provider "google" {
-  project = "muncus-dev2"
-}
 # [START cloudrun_service_image_processing_datasources]
 data "google_project" "project" {}
 
@@ -10,41 +7,41 @@ data "google_storage_project_service_account" "gcs_account" {}
 # [START cloudrun_service_image_processing_inputbucket]
 # Input Bucket
 resource "google_storage_bucket" "imageproc_input" {
- name     = "imageproc-input-bucket"
- location = "us-central1"
+  name     = "imageproc-input-bucket"
+  location = "us-central1"
 }
 
 # IAM: ensure we can read from the input bucket
 resource "google_project_iam_member" "input_reader" {
- project = data.google_project.project.project_id
-  member = "serviceAccount:${google_cloud_run_service.imageproc.template[0].spec[0].service_account_name}"
-  role = "roles/storage.objectViewer"
+  project = data.google_project.project.project_id
+  member  = "serviceAccount:${google_cloud_run_service.imageproc.template[0].spec[0].service_account_name}"
+  role    = "roles/storage.objectViewer"
 }
 # [END cloudrun_service_image_processing_inputbucket]
 
 # [START cloudrun_service_image_processing_outputbucket]
 # Output Bucket
 resource "google_storage_bucket" "imageproc_output" {
- name     = "imageproc-output-bucket"
- location = "us-central1"
+  name     = "imageproc-output-bucket"
+  location = "us-central1"
 }
 
 # IAM: Ensure we can write to the output bucket
 resource "google_project_iam_member" "output_writer" {
- project = data.google_project.project.project_id
-  member = "serviceAccount:${google_cloud_run_service.imageproc.template[0].spec[0].service_account_name}"
-  role = "roles/storage.objectCreator"
+  project = data.google_project.project.project_id
+  member  = "serviceAccount:${google_cloud_run_service.imageproc.template[0].spec[0].service_account_name}"
+  role    = "roles/storage.objectCreator"
 }
 # [END cloudrun_service_image_processing_outputbucket]
 
 # [START cloudrun_service_image_processing_pubsub]
 resource "google_pubsub_topic" "imageproc" {
- name = "imageproc-topic"
+  name = "imageproc-topic"
 }
 
 resource "google_pubsub_topic_iam_binding" "binding" {
-  topic = google_pubsub_topic.imageproc.name
-  role  = "roles/pubsub.publisher"
+  topic   = google_pubsub_topic.imageproc.name
+  role    = "roles/pubsub.publisher"
   members = ["serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"]
 }
 
@@ -54,7 +51,7 @@ resource "google_storage_notification" "notification" {
   bucket         = google_storage_bucket.imageproc_input.name
   payload_format = "JSON_API_V1"
   topic          = google_pubsub_topic.imageproc.id
-  depends_on = [google_pubsub_topic_iam_binding.binding]
+  depends_on     = [google_pubsub_topic_iam_binding.binding]
 }
 
 # Service Account for delivering messages from pubsub to cloud run
@@ -64,16 +61,16 @@ resource "google_service_account" "delivery_account" {
 
 # IAM: let this Service Account invoke the Cloud Run service.
 resource "google_project_iam_member" "cloud_run_invoker" {
- project = data.google_project.project.project_id
-  member = "serviceAccount:${google_service_account.delivery_account.email}"
-  role = "roles/run.invoker"
+  project = data.google_project.project.project_id
+  member  = "serviceAccount:${google_service_account.delivery_account.email}"
+  role    = "roles/run.invoker"
 }
 
 # subscription, to deliver pubsub notifications to Cloud Run service.
 resource "google_pubsub_subscription" "imageproc_subs" {
-  name = "imageproc-cr-sub"
-  topic = google_pubsub_topic.imageproc.name
-  ack_deadline_seconds = 90
+  name                       = "imageproc-cr-sub"
+  topic                      = google_pubsub_topic.imageproc.name
+  ack_deadline_seconds       = 90
   message_retention_duration = "1200s"
   push_config {
     push_endpoint = google_cloud_run_service.imageproc.status[0].url
@@ -86,25 +83,25 @@ resource "google_pubsub_subscription" "imageproc_subs" {
 
 # [START cloudrun_service_image_processing_crservice]
 resource "google_cloud_run_service" "imageproc" {
- name     = "imageproc-tf"
- location = "us-central1"
+  name     = "imageproc-tf"
+  location = "us-central1"
 
- template {
-   spec {
-     containers {
-       image = "gcr.io/${data.google_project.project.project_id}/imageproc"
-       env {
-         name = "BLURRED_BUCKET_NAME"
-         value = google_storage_bucket.imageproc_output.name
-       }
-     }
-   }
- }
+  template {
+    spec {
+      containers {
+        image = "gcr.io/${data.google_project.project.project_id}/imageproc"
+        env {
+          name  = "BLURRED_BUCKET_NAME"
+          value = google_storage_bucket.imageproc_output.name
+        }
+      }
+    }
+  }
 
- traffic {
-   percent         = 100
-   latest_revision = true
- }
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
 }
 # [END cloudrun_service_image_processing_crservice]
 

--- a/cloud_run_service_image_processing/main.tf
+++ b/cloud_run_service_image_processing/main.tf
@@ -26,13 +26,13 @@ resource "google_project_iam_binding" "project_token_creator" {
   members = ["serviceAccount:${google_project_service_identity.pubsub_agent.email}"]
 }
 
-resource "google_pubsub_topic" "topic" {
+resource "google_pubsub_topic" "default" {
   name = "pubsub_topic"
 }
 
 resource "google_pubsub_subscription" "subscription" {
   name  = "pubsub_subscription"
-  topic = google_pubsub_topic.topic.name
+  topic = google_pubsub_topic.default.name
   push_config {
     push_endpoint = google_cloud_run_service.default.status[0].url
     oidc_token {
@@ -87,7 +87,7 @@ resource "google_cloud_run_service" "default" {
 data "google_storage_project_service_account" "gcs_account" {}
 
 resource "google_pubsub_topic_iam_binding" "binding" {
-  topic   = google_pubsub_topic.topic.name
+  topic   = google_pubsub_topic.default.name
   role    = "roles/pubsub.publisher"
   members = ["serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"]
 }
@@ -96,7 +96,7 @@ resource "google_storage_notification" "notification" {
   provider       = google
   bucket         = google_storage_bucket.imageproc_input.name
   payload_format = "JSON_API_V1"
-  topic          = google_pubsub_topic.topic.id
+  topic          = google_pubsub_topic.default.id
   depends_on     = [google_pubsub_topic_iam_binding.binding]
 }
 # [END cloudrun_service_image_processing_notifications]

--- a/cloud_run_service_image_processing/main.tf
+++ b/cloud_run_service_image_processing/main.tf
@@ -1,0 +1,110 @@
+provider "google" {
+  project = "muncus-dev2"
+}
+# [START cloudrun_service_image_processing_datasources]
+data "google_project" "project" {}
+
+data "google_storage_project_service_account" "gcs_account" {}
+# [END cloudrun_service_image_processing_datasources]
+
+# [START cloudrun_service_image_processing_inputbucket]
+# Input Bucket
+resource "google_storage_bucket" "imageproc_input" {
+ name     = "imageproc-input-bucket"
+ location = "us-central1"
+}
+
+# IAM: ensure we can read from the input bucket
+resource "google_project_iam_member" "input_reader" {
+ project = data.google_project.project.project_id
+  member = "serviceAccount:${google_cloud_run_service.imageproc.template[0].spec[0].service_account_name}"
+  role = "roles/storage.objectViewer"
+}
+# [END cloudrun_service_image_processing_inputbucket]
+
+# [START cloudrun_service_image_processing_outputbucket]
+# Output Bucket
+resource "google_storage_bucket" "imageproc_output" {
+ name     = "imageproc-output-bucket"
+ location = "us-central1"
+}
+
+# IAM: Ensure we can write to the output bucket
+resource "google_project_iam_member" "output_writer" {
+ project = data.google_project.project.project_id
+  member = "serviceAccount:${google_cloud_run_service.imageproc.template[0].spec[0].service_account_name}"
+  role = "roles/storage.objectCreator"
+}
+# [END cloudrun_service_image_processing_outputbucket]
+
+# [START cloudrun_service_image_processing_pubsub]
+resource "google_pubsub_topic" "imageproc" {
+ name = "imageproc-topic"
+}
+
+resource "google_pubsub_topic_iam_binding" "binding" {
+  topic = google_pubsub_topic.imageproc.name
+  role  = "roles/pubsub.publisher"
+  members = ["serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"]
+}
+
+# Configure GCS notifications to pubsub
+resource "google_storage_notification" "notification" {
+  provider       = google
+  bucket         = google_storage_bucket.imageproc_input.name
+  payload_format = "JSON_API_V1"
+  topic          = google_pubsub_topic.imageproc.id
+  depends_on = [google_pubsub_topic_iam_binding.binding]
+}
+
+# Service Account for delivering messages from pubsub to cloud run
+resource "google_service_account" "delivery_account" {
+  account_id = "imageproc-invoker"
+}
+
+# IAM: let this Service Account invoke the Cloud Run service.
+resource "google_project_iam_member" "cloud_run_invoker" {
+ project = data.google_project.project.project_id
+  member = "serviceAccount:${google_service_account.delivery_account.email}"
+  role = "roles/run.invoker"
+}
+
+# subscription, to deliver pubsub notifications to Cloud Run service.
+resource "google_pubsub_subscription" "imageproc_subs" {
+  name = "imageproc-cr-sub"
+  topic = google_pubsub_topic.imageproc.name
+  ack_deadline_seconds = 90
+  message_retention_duration = "1200s"
+  push_config {
+    push_endpoint = google_cloud_run_service.imageproc.status[0].url
+    oidc_token {
+      service_account_email = google_service_account.delivery_account.email
+    }
+  }
+}
+# [END cloudrun_service_image_processing_pubsub]
+
+# [START cloudrun_service_image_processing_crservice]
+resource "google_cloud_run_service" "imageproc" {
+ name     = "imageproc-tf"
+ location = "us-central1"
+
+ template {
+   spec {
+     containers {
+       image = "gcr.io/${data.google_project.project.project_id}/imageproc"
+       env {
+         name = "BLURRED_BUCKET_NAME"
+         value = google_storage_bucket.imageproc_output.name
+       }
+     }
+   }
+ }
+
+ traffic {
+   percent         = 100
+   latest_revision = true
+ }
+}
+# [END cloudrun_service_image_processing_crservice]
+

--- a/cloud_run_service_image_processing/main.tf
+++ b/cloud_run_service_image_processing/main.tf
@@ -55,10 +55,19 @@ resource "google_storage_bucket" "imageproc_input" {
   location = "us-central1"
 }
 
+output "input_bucket_name" {
+  value = google_storage_bucket.imageproc_input.name
+}
+
 resource "google_storage_bucket" "imageproc_output" {
   name     = "output-bucket-${random_id.bucket_suffix.hex}"
   location = "us-central1"
 }
+
+output "blurred_bucket_name" {
+  value = google_storage_bucket.imageproc_output.name
+}
+
 # [END cloudrun_service_image_processing_buckets]
 
 # [START cloudrun_service_image_processing_crservice]

--- a/cloud_run_service_image_processing/main.tf
+++ b/cloud_run_service_image_processing/main.tf
@@ -1,3 +1,50 @@
+# [START cloudrun_service_existing_pubsub]
+resource "google_service_account" "sa" {
+  account_id   = "cloud-run-pubsub-invoker"
+  display_name = "Cloud Run Pub/Sub Invoker"
+}
+
+resource "google_cloud_run_service_iam_binding" "binding" {
+  location = google_cloud_run_service.default.location
+  service  = google_cloud_run_service.default.name
+  role     = "roles/run.invoker"
+  members  = ["serviceAccount:${google_service_account.sa.email}"]
+}
+
+data "google_project" "project" {
+}
+
+resource "google_project_service_identity" "pubsub_agent" {
+  provider = google-beta
+  project  = data.google_project.project.project_id
+  service  = "pubsub.googleapis.com"
+}
+
+resource "google_project_iam_binding" "project_token_creator" {
+  project  = data.google_project.project.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  members = ["serviceAccount:${google_project_service_identity.pubsub_agent.email}"]
+}
+
+resource "google_pubsub_topic" "topic" {
+  name = "pubsub_topic"
+}
+
+resource "google_pubsub_subscription" "subscription" {
+  name  = "pubsub_subscription"
+  topic = google_pubsub_topic.topic.name
+  push_config {
+    push_endpoint = google_cloud_run_service.default.status[0].url
+    oidc_token {
+      service_account_email = google_service_account.sa.email
+    }
+    attributes = {
+      x-goog-version = "v1"
+    }
+  }
+}
+# [END cloudrun_service_existing_pubsub]
+
 # [START cloudrun_service_image_processing_buckets]
 resource "random_id" "bucket_suffix" {
   byte_length = 8
@@ -40,7 +87,7 @@ resource "google_cloud_run_service" "default" {
 data "google_storage_project_service_account" "gcs_account" {}
 
 resource "google_pubsub_topic_iam_binding" "binding" {
-  topic   = google_pubsub_topic.imageproc.name
+  topic   = google_pubsub_topic.topic.name
   role    = "roles/pubsub.publisher"
   members = ["serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"]
 }
@@ -49,7 +96,7 @@ resource "google_storage_notification" "notification" {
   provider       = google
   bucket         = google_storage_bucket.imageproc_input.name
   payload_format = "JSON_API_V1"
-  topic          = google_pubsub_topic.imageproc.id
+  topic          = google_pubsub_topic.topic.id
   depends_on     = [google_pubsub_topic_iam_binding.binding]
 }
 # [END cloudrun_service_image_processing_notifications]

--- a/cloud_run_service_image_processing/main.tf
+++ b/cloud_run_service_image_processing/main.tf
@@ -93,7 +93,6 @@ resource "google_pubsub_topic_iam_binding" "binding" {
 }
 
 resource "google_storage_notification" "notification" {
-  provider       = google
   bucket         = google_storage_bucket.imageproc_input.name
   payload_format = "JSON_API_V1"
   topic          = google_pubsub_topic.default.id

--- a/cloud_run_service_pubsub/main.tf
+++ b/cloud_run_service_pubsub/main.tf
@@ -51,7 +51,7 @@ resource "google_project_iam_binding" "project_token_creator" {
 # [END cloudrun_service_pubsub_token_permissions]
 
 # [START cloudrun_service_pubsub_topic]
-resource "google_pubsub_topic" "topic" {
+resource "google_pubsub_topic" "default" {
   name = "pubsub_topic"
 }
 # [END cloudrun_service_pubsub_topic]
@@ -59,7 +59,7 @@ resource "google_pubsub_topic" "topic" {
 # [START cloudrun_service_pubsub_sub]
 resource "google_pubsub_subscription" "subscription" {
   name  = "pubsub_subscription"
-  topic = google_pubsub_topic.topic.name
+  topic = google_pubsub_topic.default.name
   push_config {
     push_endpoint = google_cloud_run_service.default.status[0].url
     oidc_token {


### PR DESCRIPTION
This PR adds sample for [Processing images from Cloud Storage tutorial](https://cloud.google.com/run/docs/tutorials/image-processing)

This tutorial relies on resources deployed in [`cloud_run_service_pubsub`.](https://github.com/terraform-google-modules/terraform-docs-samples/tree/main/cloud_run_service_pubsub) Those resources are contained in the `cloudrun_service_existing_pubsub` region tag.

This PR also updates the name of a pubsub topic for consistency.  