### PR TITLE
Changed bucket name to use a bucket_prefix

### DIFF
--- a/cloudfunctions2_basic_auditlogs/main.tf
+++ b/cloudfunctions2_basic_auditlogs/main.tf
@@ -29,7 +29,7 @@ resource "google_service_account" "account" {
 # Here we use Audit Logs to monitor the bucket so path patterns can be used in the example of
 # google_cloudfunctions2_function below (Audit Log events have path pattern support)
 resource "google_storage_bucket" "audit-log-bucket" {
-  name     = "gcf-auditlog-bucket"
+  name     = "${random_id.bucket_prefix.hex}-gcf-auditlog-bucket"
   location = "us-central1"  # The trigger must be in the same location as the bucket
   uniform_bucket_level_access = true
 }


### PR DESCRIPTION
In the logs, the hard-coded bucket name shows up as an error:

```
TestSamples/1/cloudfunctions2_basic_auditlogs 2022-09-26T20:50:04Z command.go:185: ╵
TestSamples/1/cloudfunctions2_basic_auditlogs 2022-09-26T20:50:04Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1; ╷
│ Error: googleapi: Error 409: The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again., conflict
│ 
│   with google_storage_bucket.audit-log-bucket,
│   on main.tf line 31, in resource "google_storage_bucket" "audit-log-bucket":
│   31: resource "google_storage_bucket" "audit-log-bucket" {
│ 
╵}
    apply.go:34: 
        	Error Trace:	apply.go:34
        	            				terraform.go:398
        	            				terraform.go:408
        	            				terraform.go:432
        	            				stages.go:31
        	            				terraform.go:432
        	Error:      	Received unexpected error:
        	            	FatalError{Underlying: error while running command: exit status 1; ╷
        	            	│ Error: googleapi: Error 409: The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again., conflict
        	            	│ 
        	            	│   with google_storage_bucket.audit-log-bucket,
        	            	│   on main.tf line 31, in resource "google_storage_bucket" "audit-log-bucket":
        	            	│   31: resource "google_storage_bucket" "audit-log-bucket" {
        	            	│ 
        	            	╵}
        	Test:       	TestSamples/1/cloudfunctions2_basic_auditlogs

```