### PR TITLE
Add provider requirement to functions v2 to make error message more obvious

### DIFF
--- a/cloudfunctions2_basic/main.tf
+++ b/cloudfunctions2_basic/main.tf
@@ -1,4 +1,13 @@
 # [START functions_v2_basic]
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = ">= 4.34.0"
+    }
+  }
+}
+
 resource "random_id" "bucket_prefix" {
   byte_length = 8
 }

--- a/cloudfunctions2_basic_auditlogs/main.tf
+++ b/cloudfunctions2_basic_auditlogs/main.tf
@@ -4,6 +4,15 @@
 # and the docs:
 # https://cloud.google.com/eventarc/docs/path-patterns
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = ">= 4.34.0"
+    }
+  }
+}
+
 resource "random_id" "bucket_prefix" {
   byte_length = 8
 }

--- a/cloudfunctions2_basic_gcs/main.tf
+++ b/cloudfunctions2_basic_gcs/main.tf
@@ -1,5 +1,14 @@
 # [START functions_v2_basic_gcs]
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = ">= 4.34.0"
+    }
+  }
+}
+
 resource "random_id" "bucket_prefix" {
   byte_length = 8
 }

--- a/cloudfunctions2_full/main.tf
+++ b/cloudfunctions2_full/main.tf
@@ -1,4 +1,13 @@
 # [START functions_v2_full]
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = ">= 4.34.0"
+    }
+  }
+}
+
 resource "random_id" "bucket_prefix" {
   byte_length = 8
 }


### PR DESCRIPTION
This will add the minimum required version in order to make potential errors more obvious:
Before:
```bash
Error: Invalid resource type

  on main.tf line 27, in resource "google_cloudfunctions2_function" "function":
  27: resource "google_cloudfunctions2_function" "function" {

The provider hashicorp/google does not support resource type "google_cloudfunctions2_function". Did you mean "google_cloudfunctions_function"?
```

After:
```bash
Error: Inconsistent dependency lock file

The following dependency selections recorded in the lock file are inconsistent with the current configuration:
  - provider registry.terraform.io/hashicorp/google: locked version selection 4.32.0 doesn't match the updated version constraints ">= 4.34.0"

To update the locked dependency selections to match a changed configuration, run:
  terraform init -upgrade
```