### PR TITLE
chore: add notebooks.googleapis.com to test setup

### DIFF
--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -60,5 +60,6 @@ module "projects" {
     "workflows.googleapis.com",
     "cloudkms.googleapis.com",
     "servicenetworking.googleapis.com",
+    "notebooks.googleapis.com",
   ]
 }


### PR DESCRIPTION
Sometimes tests are flaky for vertex AI with API enablement eventual consistency. This adds the API to test setup which should help. If it continues to be flaky, we can add this to retry https://github.com/terraform-google-modules/terraform-docs-samples/blob/f7e01ec4a76d6ea38ce0e51ea738a0a5c0546415/test/integration/sample_test.go#L27-L31