### PR TITLE
chore: retry service activation, IAM

### DIFF
--- a/test/integration/sample_test.go
+++ b/test/integration/sample_test.go
@@ -28,6 +28,8 @@ type testGroups struct {
 var retryErrors = map[string]string{
 	// IAM for Eventarc service agent is eventually consistent
 	".*Permission denied while using the Eventarc Service Agent.*": "Eventarc Service Agent IAM is eventually consistent",
+	// API activation is eventually consistent.
+	".*SERVICE_DISABLED.*": "Service enablement is eventually consistent",
 }
 
 func TestSamples(t *testing.T) {

--- a/test/integration/sample_test.go
+++ b/test/integration/sample_test.go
@@ -30,6 +30,8 @@ var retryErrors = map[string]string{
 	".*Permission denied while using the Eventarc Service Agent.*": "Eventarc Service Agent IAM is eventually consistent",
 	// API activation is eventually consistent.
 	".*SERVICE_DISABLED.*": "Service enablement is eventually consistent",
+	// Retry function GCS access
+        ".*does not have storage.objects.get access.*": "GCS IAM is eventually consistent",
 }
 
 func TestSamples(t *testing.T) {


### PR DESCRIPTION
Still see a few flakes for service activation after https://github.com/terraform-google-modules/terraform-docs-samples/pull/180, so we retry these now. Also added `*does not have storage.objects.get access` to retry GCS IAM.