### PR TITLE
privateca_quickstart: Removed read-only attribute, enabled necessary API, fixed faulty attribute reference

### DIFF
--- a/privateca_quickstart/main.tf
+++ b/privateca_quickstart/main.tf
@@ -24,7 +24,6 @@ resource "google_privateca_ca_pool" "default" {
   name = "my-ca-pool"
   location = "us-central1"
   tier = "ENTERPRISE"
-  project = "project-id"
   publishing_options {
     publish_ca_cert = true
     publish_crl = true
@@ -53,7 +52,6 @@ resource "google_privateca_ca_pool" "default" {
 resource "google_privateca_certificate_authority" "test-ca" {
   certificate_authority_id = "my-authority"
   location = "us-central1"
-  project = "project-id"
   pool = google_privateca_ca_pool.default.name
   config {
     subject_config {
@@ -92,7 +90,6 @@ resource "google_privateca_certificate_authority" "test-ca" {
 resource "google_privateca_certificate" "default" {
   pool = google_privateca_ca_pool.default.name
   certificate_authority = google_privateca_certificate_authority.test-ca.certificate_authority_id
-  project = "project-id"
   location = "us-central1"
   lifetime = "860s"
   name = "my-certificate"

--- a/privateca_quickstart/main.tf
+++ b/privateca_quickstart/main.tf
@@ -2,12 +2,16 @@
 provider google{}
 provider tls{}
 
+resource "google_project_service" "privateca_api" {
+  service            = "privateca.googleapis.com"
+  disable_on_destroy = false
+}
+
 resource "tls_private_key" "example" {
   algorithm   = "RSA"
 }
 
 resource "tls_cert_request" "example" {
-  key_algorithm   = "RSA"
   private_key_pem = tls_private_key.example.private_key_pem
 
   subject {
@@ -50,7 +54,7 @@ resource "google_privateca_certificate_authority" "test-ca" {
   certificate_authority_id = "my-authority"
   location = "us-central1"
   project = "project-id"
-  pool = google_privateca_ca_pool.pool.name
+  pool = google_privateca_ca_pool.default.name
   config {
     subject_config {
       subject {
@@ -86,7 +90,7 @@ resource "google_privateca_certificate_authority" "test-ca" {
 }
 
 resource "google_privateca_certificate" "default" {
-  pool = google_privateca_ca_pool.pool.name
+  pool = google_privateca_ca_pool.default.name
   certificate_authority = google_privateca_certificate_authority.test-ca.certificate_authority_id
   project = "project-id"
   location = "us-central1"


### PR DESCRIPTION

Example appears here:

https://cloud.google.com/certificate-authority-service/docs/using-terraform