### PR TITLE
Added example for adding a disk to a VM

### DIFF
--- a/compute_add_persistent_disk/main.tf
+++ b/compute_add_persistent_disk/main.tf
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
+# [START compute_create_persistent_disk]
 resource "google_compute_disk" "default" {
   name = "disk-data"
   type = "pd-standard"
   zone = "us-west1-a"
   size = "5"
 }
+# [END compute_create_persistent_disk]
 
+# [START compute_attach_persistent_disk]
 resource "google_compute_instance" "test_node" {
   name         = "test-node"
   machine_type = "f1-micro"
@@ -43,3 +46,4 @@ resource "google_compute_instance" "test_node" {
     }
   }
 }
+# [END compute_attach_persistent_disk]

--- a/compute_add_persistent_disk/main.tf
+++ b/compute_add_persistent_disk/main.tf
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+resource "google_project_service" "compute_api" {
+  service            = "compute.googleapis.com"
+  disable_on_destroy = false
+}
+
 # [START compute_create_persistent_disk]
+# Using pd-standard because it's the default for Compute Engine
+
 resource "google_compute_disk" "default" {
   name = "disk-data"
   type = "pd-standard"

--- a/compute_add_persistent_disk/main.tf
+++ b/compute_add_persistent_disk/main.tf
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_compute_disk" "default" {
+  name = "disk-data"
+  type = "pd-standard"
+  zone = "us-west1-a"
+  size = "5"
+}
+
+resource "google_compute_instance" "test_node" {
+  name         = "test-node"
+  machine_type = "f1-micro"
+  zone         = "us-west1-a"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+  attached_disk {
+    source      = google_compute_disk.default.id
+    device_name = google_compute_disk.default.name
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      // Ephemeral IP
+    }
+  }
+}


### PR DESCRIPTION
Planning to include on this page:

https://cloud.google.com/compute/docs/disks/add-persistent-disk