### PR TITLE
Removed comment to avoid technical debt

### DIFF
--- a/compute_add_persistent_disk/main.tf
+++ b/compute_add_persistent_disk/main.tf
@@ -20,8 +20,6 @@ resource "google_project_service" "compute_api" {
 }
 
 # [START compute_create_persistent_disk]
-# Using pd-standard because it's the default for Compute Engine
-
 resource "google_compute_disk" "default" {
   name = "disk-data"
   type = "pd-standard"


### PR DESCRIPTION
In the not-too-distant future, we'll want to nudge users toward the new hyperdisk family (newer generation of disks), so we might want to remove this comment from the sample to avoid the debt.