### PR TITLE
chore: pin lint to 1.8

### DIFF
--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -22,4 +22,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.8'


### PR DESCRIPTION
Pin lint to 1.8 for now. 1.9 rolls out TF lint. I will create a PR to update to latest incorporating changes for TF lint.