### PR TITLE
chore(dns): example cloud dns example with dnssec

### DIFF
--- a/dns_managed_zone_with_dnssec/main.tf
+++ b/dns_managed_zone_with_dnssec/main.tf
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# Google Cloud Documentation: https://cloud.google.com/dns/docs/dnssec-config#creating
+# [START dns_managed_zone_with_dnssec]
+resource "google_dns_managed_zone" "example" {
+  name        = "example-zone-name"
+  dns_name    = "myzone.example.com."
+  description = "Example Signed Zone"
+  dnssec_config {
+      state = "on"
+  }
+}
+# [END dns_managed_zone_with_dnssec]

--- a/dns_managed_zone_with_dnssec/main.tf
+++ b/dns_managed_zone_with_dnssec/main.tf
@@ -18,7 +18,7 @@
 # [START dns_managed_zone_with_dnssec]
 resource "google_dns_managed_zone" "example" {
   name        = "example-zone-name"
-  dns_name    = "myzone.example.com."
+  dns_name    = "example.com."
   description = "Example Signed Zone"
   dnssec_config {
     state = "on"

--- a/dns_managed_zone_with_dnssec/main.tf
+++ b/dns_managed_zone_with_dnssec/main.tf
@@ -21,7 +21,7 @@ resource "google_dns_managed_zone" "example" {
   dns_name    = "myzone.example.com."
   description = "Example Signed Zone"
   dnssec_config {
-      state = "on"
+    state = "on"
   }
 }
 # [END dns_managed_zone_with_dnssec]

--- a/dns_managed_zone_with_dnssec/test.yaml
+++ b/dns_managed_zone_with_dnssec/test.yaml
@@ -1,0 +1,20 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintTest
+metadata:
+  name: dns_managed_zone_with_dnssec
+spec:
+  skip: true


### PR DESCRIPTION
Add cloud dns example for DNSSEC

Reference: https://cloud.google.com/dns/docs/dnssec-config#gcloud_1