### PR TITLE
Bugfix - Connectivity Tests

### DIFF
--- a/dns_managed_zone_with_wildcard_certificate/main.tf
+++ b/dns_managed_zone_with_wildcard_certificate/main.tf
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  domain = "example.me"
+  name   = "prefixname"
+}
+
+resource "random_id" "tf_prefix" {
+  byte_length = 4
+}
+
+resource "google_project_service" "certificatemanager_svc" {
+  service            = "certificatemanager.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_dns_managed_zone" "default" {
+  name        = "example-mz-${random_id.tf_prefix.hex}"
+  dns_name    = "${local.domain}."
+  description = "Example DNS zone"
+  labels = {
+    "terraform" : true
+  }
+  visibility    = "public"
+  force_destroy = true
+}
+
+resource "google_certificate_manager_dns_authorization" "default" {
+  name        = "${local.name}-dnsauth-${random_id.tf_prefix.hex}"
+  description = "The default dns auth"
+  domain      = local.domain
+  labels = {
+    "terraform" : true
+  }
+}
+
+resource "google_dns_record_set" "cname" {
+  name         = google_certificate_manager_dns_authorization.default.dns_resource_record[0].name
+  managed_zone = google_dns_managed_zone.default.name
+  type         = google_certificate_manager_dns_authorization.default.dns_resource_record[0].type
+  ttl          = 300
+  rrdatas      = [google_certificate_manager_dns_authorization.default.dns_resource_record[0].data]
+}
+
+resource "google_certificate_manager_certificate" "root_cert" {
+  name        = "${local.name}-rootcert-${random_id.tf_prefix.hex}"
+  description = "The wildcard cert"
+  managed {
+    domains = [local.domain, "*.${local.domain}"]
+    dns_authorizations = [
+      google_certificate_manager_dns_authorization.default.id
+    ]
+  }
+  labels = {
+    "terraform" : true
+  }
+}
+
+resource "google_certificate_manager_certificate_map" "certificate_map" {
+  name        = "${local.name}-certmap-${random_id.tf_prefix.hex}"
+  description = "${local.domain} certificate map"
+  labels = {
+    "terraform" : true
+  }
+}
+
+resource "google_certificate_manager_certificate_map_entry" "first_entry" {
+  name        = "${local.name}-first-entry-${random_id.tf_prefix.hex}"
+  description = "example certificate map entry"
+  map         = google_certificate_manager_certificate_map.certificate_map.name
+  labels = {
+    "terraform" : true
+  }
+  certificates = [google_certificate_manager_certificate.root_cert.id]
+  hostname     = local.domain
+}
+
+resource "google_certificate_manager_certificate_map_entry" "second_entry" {
+  name        = "${local.name}-second-entity-${random_id.tf_prefix.hex}"
+  description = "example certificate map entry"
+  map         = google_certificate_manager_certificate_map.certificate_map.name
+  labels = {
+    "terraform" : true
+  }
+  certificates = [google_certificate_manager_certificate.root_cert.id]
+  hostname     = "*.${local.domain}"
+}
+output "domain_name_servers" {
+  value = google_dns_managed_zone.default.name_servers
+}
+output "certificate_map" {
+  value = google_certificate_manager_certificate_map.certificate_map.id
+}

--- a/network_management_connectivity_test_addresses/main.tf
+++ b/network_management_connectivity_test_addresses/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,48 +15,106 @@
  */
 
 # [START networkmanagement_test_addresses]
-resource "google_network_management_connectivity_test" "address_test" {
+resource "google_network_management_connectivity_test" "default" {
   name = "conn-test-addr"
   source {
     ip_address   = google_compute_address.source_addr.address
     project_id   = google_compute_address.source_addr.project
-    network      = google_compute_network.vpc.id
+    network      = google_compute_network.default.id
     network_type = "GCP_NETWORK"
   }
 
   destination {
     ip_address = google_compute_address.dest_addr.address
     project_id = google_compute_address.dest_addr.project
-    network    = google_compute_network.vpc.id
+    network    = google_compute_network.default.id
+    port       = "80"
   }
 
   protocol = "UDP"
 }
 
-resource "google_compute_network" "vpc" {
-  name = "connectivity-vpc"
+resource "google_compute_network" "default" {
+  name                    = "connectivity-vpc"
+  auto_create_subnetworks = false
 }
 
-resource "google_compute_subnetwork" "subnet" {
+resource "google_compute_subnetwork" "default" {
   name          = "connectivity-vpc-subnet"
-  ip_cidr_range = "10.0.0.0/16"
+  ip_cidr_range = "10.0.0.0/8"
   region        = "us-central1"
-  network       = google_compute_network.vpc.id
+  network       = google_compute_network.default.id
+}
+
+resource "google_compute_firewall" "default" {
+  name    = "allow-incoming-all"
+  network = google_compute_network.default.name
+
+  allow {
+    protocol = "all"
+  }
+
+  source_ranges = ["0.0.0.0/0"]
 }
 
 resource "google_compute_address" "source_addr" {
   name         = "src-addr"
-  subnetwork   = google_compute_subnetwork.subnet.id
+  subnetwork   = google_compute_subnetwork.default.id
   address_type = "INTERNAL"
-  address      = "10.0.42.42"
+  address      = "10.0.0.42"
   region       = "us-central1"
 }
 
 resource "google_compute_address" "dest_addr" {
   name         = "dest-addr"
-  subnetwork   = google_compute_subnetwork.subnet.id
+  subnetwork   = google_compute_subnetwork.default.id
   address_type = "INTERNAL"
-  address      = "10.0.43.43"
+  address      = "10.0.0.43"
   region       = "us-central1"
+}
+
+resource "google_compute_instance" "source" {
+  name         = "source-vm1"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.default.id
+    }
+  }
+
+  network_interface {
+    network    = "connectivity-vpc"
+    subnetwork = google_compute_subnetwork.default.id
+    network_ip = "10.0.0.42"
+    access_config {
+    }
+  }
+}
+
+resource "google_compute_instance" "destination" {
+  name         = "dest-vm1"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.default.id
+    }
+  }
+
+  network_interface {
+    network    = "connectivity-vpc"
+    subnetwork = google_compute_subnetwork.default.id
+    network_ip = "10.0.0.43"
+    access_config {
+    }
+  }
+}
+
+data "google_compute_image" "default" {
+  family  = "debian-11"
+  project = "debian-cloud"
 }
 # [END networkmanagement_test_addresses]

--- a/network_management_connectivity_test_addresses/main.tf
+++ b/network_management_connectivity_test_addresses/main.tf
@@ -85,7 +85,7 @@ resource "google_compute_instance" "source" {
   }
 
   network_interface {
-    network    = "connectivity-vpc"
+    network    = google_compute_network.default.id
     subnetwork = google_compute_subnetwork.default.id
     network_ip = "10.0.0.42"
     access_config {
@@ -105,7 +105,7 @@ resource "google_compute_instance" "destination" {
   }
 
   network_interface {
-    network    = "connectivity-vpc"
+    network    = google_compute_network.default.id
     subnetwork = google_compute_subnetwork.default.id
     network_ip = "10.0.0.43"
     access_config {


### PR DESCRIPTION
As per the latest docs, ip addresses used in Connectivity tests must be already in use by other resources like Compute VM.