### PR TITLE
TF for Certificate Manager: /certificate-manager/docs/deploy-google-managed-lb-auth

### DIFF
--- a/certificate_manager/google_managed_lb_auth/main.tf
+++ b/certificate_manager/google_managed_lb_auth/main.tf
@@ -99,12 +99,12 @@ resource "google_compute_managed_ssl_certificate" "default" {
 
 # [START certificatemanager_google_managed_lb_auth_target_https_proxy]
 resource "google_compute_target_https_proxy" "default" {
-  name            = "test-proxy"
+  name = "test-proxy"
 
-# Update the {certificate_map_name} and uncomment the certificate_map attribute
-#  certificate_map = "//certificatemanager.googleapis.com/projects/${data.google_project.default.project_id}/locations/global/certificateMaps/{certificate_map_name}"
+  # Update the {certificate_map_name} and uncomment the certificate_map attribute
+  #  certificate_map = "//certificatemanager.googleapis.com/projects/${data.google_project.default.project_id}/locations/global/certificateMaps/{certificate_map_name}"
 
-  url_map         = google_compute_url_map.default.id
+  url_map = google_compute_url_map.default.id
   ssl_certificates = [
     google_compute_managed_ssl_certificate.default.name
   ]

--- a/certificate_manager/google_managed_lb_auth/main.tf
+++ b/certificate_manager/google_managed_lb_auth/main.tf
@@ -1,0 +1,175 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  domain = "example.me"
+  name   = "prefixname"
+}
+
+resource "random_id" "tf_prefix" {
+  byte_length = 4
+}
+
+data "google_project" "default" {
+}
+
+# [START certificatemanager_google_managed_lb_auth_servicess]
+resource "google_project_service" "certificatemanager_svc" {
+  service            = "certificatemanager.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "compute_api" {
+  service                    = "compute.googleapis.com"
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}
+# [END certificatemanager_google_managed_lb_auth_services]
+
+# [START certificatemanager_google_managed_lb_auth_certificate]
+resource "google_certificate_manager_certificate" "default" {
+  name        = "${local.name}-rootcert-${random_id.tf_prefix.hex}"
+  description = "Cert with LB authorization"
+  managed {
+    domains = [local.domain]
+  }
+  labels = {
+    "terraform" : true
+  }
+}
+# [END certificatemanager_google_managed_lb_auth_certificate]
+
+# [START certificatemanager_google_managed_lb_auth_map]
+resource "google_certificate_manager_certificate_map" "default" {
+  name        = "certmap1"
+  description = "${local.domain} certificate map"
+  labels = {
+    "terraform" : true
+  }
+}
+# [END certificatemanager_google_managed_lb_auth_map]
+
+# [START certificatemanager_google_managed_lb_auth_map_entry]
+resource "google_certificate_manager_certificate_map_entry" "default" {
+  name        = "${local.name}-first-entry-${random_id.tf_prefix.hex}"
+  description = "example certificate map entry"
+  map         = google_certificate_manager_certificate_map.default.name
+  labels = {
+    "terraform" : true
+  }
+  certificates = [google_certificate_manager_certificate.default.id]
+  hostname     = local.domain
+}
+# [END certificatemanager_google_managed_lb_auth_map_entry]
+
+# [START cloudloadbalancing_google_managed_lb_auth_addr]
+resource "google_compute_global_address" "default" {
+  provider = google-beta
+  name     = "myservice-service-ip"
+
+  # Use an explicit depends_on clause to wait until API is enabled
+  depends_on = [
+    google_project_service.compute_api
+  ]
+}
+# [END cloudloadbalancing_google_managed_lb_auth_addr]
+
+# [START cloudloadbalancing_google_managed_lb_auth_cert]
+resource "google_compute_managed_ssl_certificate" "default" {
+  name = "myservice-ssl-cert"
+
+  managed {
+    domains = [local.domain]
+  }
+}
+# [END cloudloadbalancing_google_managed_lb_auth_cert]
+
+# [START certificatemanager_google_managed_lb_auth_target_https_proxy] 
+resource "google_compute_target_https_proxy" "default" {
+  name            = "test-proxy"
+  certificate_map = "//certificatemanager.googleapis.com/projects/${data.google_project.default.project_id}/locations/global/certificateMaps/certmap1"
+  url_map         = google_compute_url_map.default.id
+  ssl_certificates = [
+    google_compute_managed_ssl_certificate.default.name
+  ]
+  depends_on = [
+    google_compute_managed_ssl_certificate.default
+  ]
+}
+# [END certificatemanager_google_managed_lb_auth_target_https_proxy]
+
+# [START cloudloadbalancing_google_managed_lb_auth_forwarding]
+resource "google_compute_global_forwarding_rule" "default" {
+  provider              = google-beta
+  name                  = "myservice-lb-fr"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  target                = google_compute_target_https_proxy.default.id
+  ip_address            = google_compute_global_address.default.id
+  port_range            = "443"
+  depends_on            = [google_compute_target_https_proxy.default]
+}
+# [END cloudloadbalancing_google_managed_lb_auth_forwarding]
+
+# [START certificatemanager_google_managed_lb_auth_backend]
+resource "google_storage_bucket" "default" {
+  name                        = "${random_id.tf_prefix.hex}-bucket-1"
+  location                    = "us-east1"
+  uniform_bucket_level_access = true
+  storage_class               = "STANDARD"
+  // delete bucket and contents on destroy.
+  force_destroy = true
+}
+
+resource "google_storage_bucket_iam_member" "default" {
+  bucket = google_storage_bucket.default.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+
+resource "google_compute_backend_bucket" "default" {
+  name        = "bucket-1"
+  bucket_name = google_storage_bucket.default.name
+}
+# [END certificatemanager_google_managed_lb_auth_backend]
+
+# [START cloudloadbalancing_google_managed_lb_auth_urlmap_https]
+resource "google_compute_url_map" "default" {
+  name            = "myservice-https-urlmap"
+  default_service = google_compute_backend_bucket.default.id
+}
+# [END cloudloadbalancing_google_managed_lb_auth_urlmap_https]
+
+# [START cloudloadbalancing_google_managed_lb_auth_proxy]
+resource "google_compute_target_http_proxy" "default" {
+  name    = "myservice-http-proxy"
+  url_map = google_compute_url_map.default.id
+
+  depends_on = [
+    google_compute_url_map.default
+  ]
+}
+# [END cloudloadbalancing_google_managed_lb_auth_proxy]
+
+
+
+output "certificate_map" {
+  value = google_certificate_manager_certificate_map.default.id
+}
+
+output "load_balancer_ip_addr" {
+  value = google_compute_global_address.default.address
+}
+

--- a/certificate_manager/google_managed_lb_auth/main.tf
+++ b/certificate_manager/google_managed_lb_auth/main.tf
@@ -59,9 +59,6 @@ resource "google_certificate_manager_certificate_map" "default" {
   labels = {
     "terraform" : true
   }
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 # [END certificatemanager_google_managed_lb_auth_map]
 
@@ -103,7 +100,11 @@ resource "google_compute_managed_ssl_certificate" "default" {
 # [START certificatemanager_google_managed_lb_auth_target_https_proxy]
 resource "google_compute_target_https_proxy" "default" {
   name            = "test-proxy"
-  certificate_map = "//certificatemanager.googleapis.com/projects/${data.google_project.default.project_id}/locations/global/certificateMaps/certmap1"
+
+# Update the {certificate_map_name} and uncomment the certificate_map attribute
+#  certificate_map = 
+"//certificatemanager.googleapis.com/projects/${data.google_project.default.project_id}/locations/global/certificateMaps/{certificate_map_name}"
+
   url_map         = google_compute_url_map.default.id
   ssl_certificates = [
     google_compute_managed_ssl_certificate.default.name

--- a/certificate_manager/google_managed_lb_auth/main.tf
+++ b/certificate_manager/google_managed_lb_auth/main.tf
@@ -23,10 +23,6 @@ resource "random_id" "tf_prefix" {
   byte_length = 4
 }
 
-# Uncomment the `google_project.default` resource 
-#data "google_project" "default" {
-#}
-
 # [START certificatemanager_google_managed_lb_auth_servicess]
 resource "google_project_service" "certificatemanager_svc" {
   service            = "certificatemanager.googleapis.com"
@@ -99,6 +95,11 @@ resource "google_compute_managed_ssl_certificate" "default" {
 # [END cloudloadbalancing_google_managed_lb_auth_cert]
 
 # [START certificatemanager_google_managed_lb_auth_target_https_proxy]
+
+# Uncomment the `google_project.default` resource
+#data "google_project" "default" {
+#}
+
 resource "google_compute_target_https_proxy" "default" {
   name = "test-proxy"
 

--- a/certificate_manager/google_managed_lb_auth/main.tf
+++ b/certificate_manager/google_managed_lb_auth/main.tf
@@ -97,7 +97,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
 }
 # [END cloudloadbalancing_google_managed_lb_auth_cert]
 
-# [START certificatemanager_google_managed_lb_auth_target_https_proxy] 
+# [START certificatemanager_google_managed_lb_auth_target_https_proxy]
 resource "google_compute_target_https_proxy" "default" {
   name            = "test-proxy"
   certificate_map = "//certificatemanager.googleapis.com/projects/${data.google_project.default.project_id}/locations/global/certificateMaps/certmap1"
@@ -151,18 +151,6 @@ resource "google_compute_url_map" "default" {
   default_service = google_compute_backend_bucket.default.id
 }
 # [END cloudloadbalancing_google_managed_lb_auth_urlmap_https]
-
-# [START cloudloadbalancing_google_managed_lb_auth_proxy]
-resource "google_compute_target_http_proxy" "default" {
-  name    = "myservice-http-proxy"
-  url_map = google_compute_url_map.default.id
-
-  depends_on = [
-    google_compute_url_map.default
-  ]
-}
-# [END cloudloadbalancing_google_managed_lb_auth_proxy]
-
 
 
 output "certificate_map" {

--- a/certificate_manager/google_managed_lb_auth/main.tf
+++ b/certificate_manager/google_managed_lb_auth/main.tf
@@ -102,8 +102,7 @@ resource "google_compute_target_https_proxy" "default" {
   name            = "test-proxy"
 
 # Update the {certificate_map_name} and uncomment the certificate_map attribute
-#  certificate_map = 
-"//certificatemanager.googleapis.com/projects/${data.google_project.default.project_id}/locations/global/certificateMaps/{certificate_map_name}"
+#  certificate_map = "//certificatemanager.googleapis.com/projects/${data.google_project.default.project_id}/locations/global/certificateMaps/{certificate_map_name}"
 
   url_map         = google_compute_url_map.default.id
   ssl_certificates = [

--- a/certificate_manager/google_managed_lb_auth/main.tf
+++ b/certificate_manager/google_managed_lb_auth/main.tf
@@ -59,6 +59,9 @@ resource "google_certificate_manager_certificate_map" "default" {
   labels = {
     "terraform" : true
   }
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 # [END certificatemanager_google_managed_lb_auth_map]
 

--- a/certificate_manager/google_managed_lb_auth/main.tf
+++ b/certificate_manager/google_managed_lb_auth/main.tf
@@ -23,8 +23,9 @@ resource "random_id" "tf_prefix" {
   byte_length = 4
 }
 
-data "google_project" "default" {
-}
+# Uncomment the `google_project.default` resource 
+#data "google_project" "default" {
+#}
 
 # [START certificatemanager_google_managed_lb_auth_servicess]
 resource "google_project_service" "certificatemanager_svc" {


### PR DESCRIPTION
Intending to add "Terraform"-equivalent tabs to this page:

https://cloud.google.com/certificate-manager/docs/deploy-google-managed-lb-auth