### PR TITLE
fix: clarify comments in IAM deny policy example

### DIFF
--- a/iam_create_deny_policy/main.tf
+++ b/iam_create_deny_policy/main.tf
@@ -21,14 +21,14 @@
 data "google_project" "default" {
 }
 
-# Create an Example Service A/C
+# Create a service account
 resource "google_service_account" "default" {
   display_name = "IAM Deny Example - Service Account"
   account_id   = "example-sa"
   project      = data.google_project.default.project_id
 }
 
-# Create IAM Deny Policy for the Example SA
+# Create an IAM deny policy that denies a permission for the service account
 resource "google_iam_deny_policy" "default" {
   provider     = google-beta
   parent       = urlencode("cloudresourcemanager.googleapis.com/projects/${data.google_project.default.project_id}")


### PR DESCRIPTION
In the example, you're not creating a deny policy "for the service account"; the deny policy is attached to the project, not the service account.