### PR TITLE
add to migration script

### DIFF
--- a/migrate-csv.sh
+++ b/migrate-csv.sh
@@ -7,6 +7,11 @@
 # Make sure that the csv fed into this script has no header, 
 # and ends with a new line
 
+# Formatting variables
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
 INPUT=$1
 IFS=','
 [ ! -f $INPUT ] && { echo "$INPUT file not found"; exit 1; }

--- a/migrate-csv.sh
+++ b/migrate-csv.sh
@@ -34,19 +34,24 @@ while read source destination
 do
     # Remove carriage return from destination variable
     destination=$(echo $destination | sed 's/\r//g')
-	echo -e "\n\xe2\x88\xb4 Moving ${GREEN}${source}${NC} to ${GREEN}${destination}${NC}"
+	echo -e "\n\xe2\x88\xb4 Moving ${GREEN}${source}${NC} to ${GREEN}${destination}${NC}\n"
     git mv $source $destination 
     git commit -m "move ${source} to ${destination}"
+    echo -e "\n"
     # Save the ID of the revision with the moved sample for use later in merge
     saved=`git rev-parse HEAD`
     # Reset to HEAD, temporarily rename source, and commit
     git reset --hard HEAD^
     git mv ${source} ${source}-copy
+    echo -e "\n"
     git commit -m "temporary copy of ${source}"
     # Merge current with saved revision and commit
+    echo -e "\n"
     git merge $saved
+    echo -e "\n"
     git commit -a -m "merge copy of ${source}"
     # Rename source back to original name and commit
     git mv ${source}-copy ${source}
+    echo -e "\n"
     git commit -m "merge original copy of ${source}"
 done < $INPUT

--- a/migrate-csv.sh
+++ b/migrate-csv.sh
@@ -17,7 +17,8 @@ INPUT=$1
 IFS=','
 [ ! -f $INPUT ] && { echo "$INPUT file not found"; exit 1; }
 
-echo -e "${GREEN}Checking for source and destinations in CSV file${NC}"
+echo -e "${GREEN}Preview:\n${NC}"
+count=0
 while read source destination
 do
    if [ ! -d "${source}" ]
@@ -26,7 +27,9 @@ do
     exit 2
    fi;
    echo -e "${ARROW} ./${source}${NC} will be copied to ${GREEN}./${destination}${NC}"
+   let count+=1
 done < $INPUT
+echo -e "\n${GREEN}Number of samples to be copied: ${count}${NC} \n---"
 exit 
 while read source destination
 do

--- a/migrate-csv.sh
+++ b/migrate-csv.sh
@@ -37,14 +37,16 @@ do
 	echo -e "\n\xe2\x88\xb4 Moving ${GREEN}${source}${NC} to ${GREEN}${destination}${NC}"
     git mv $source $destination 
     git commit -m "move ${source} to ${destination}"
+    # Save the ID of the revision with the moved sample for use later in merge
     saved=`git rev-parse HEAD`
+    # Reset to HEAD, temporarily rename source, and commit
     git reset --hard HEAD^
     git mv ${source} ${source}-copy
     git commit -m "temporary copy of ${source}"
-
+    # Merge current with saved revision and commit
     git merge $saved
     git commit -a -m "merge copy of ${source}"
-
+    # Rename source back to original name and commit
     git mv ${source}-copy ${source}
     git commit -m "merge original copy of ${source}"
 done < $INPUT

--- a/migrate-csv.sh
+++ b/migrate-csv.sh
@@ -9,7 +9,7 @@
 
 INPUT=$1
 IFS=','
-[ ! -f $INPUT ] && { echo "$INPUT file not found"; exit 99; }
+[ ! -f $INPUT ] && { echo "$INPUT file not found"; exit 1; }
 while read source destination
 do
    if [ ! -d "${source}" ]

--- a/migrate-csv.sh
+++ b/migrate-csv.sh
@@ -11,20 +11,23 @@
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
+ARROW='\033[0;32m\xe2\x89\xab'
 
 INPUT=$1
 IFS=','
 [ ! -f $INPUT ] && { echo "$INPUT file not found"; exit 1; }
+
+echo -e "${GREEN}Checking for source and destinations in CSV file${NC}"
 while read source destination
 do
    if [ ! -d "${source}" ]
    then
-    echo "Directory ${source} does not exist. "
-    echo "Make sure all directories in csv exist."
+    echo -e "---\n${RED}Error:${NC} Directory ${RED}${source} ${NC}does not exist. Make sure all directories in csv exist. \n---"
     exit 2
    fi;
+   echo -e "${ARROW} ./${source}${NC} will be copied to ${GREEN}./${destination}${NC}"
 done < $INPUT
-
+exit 
 while read source destination
 do
     destination=$(echo $destination | sed 's/\r//g')

--- a/migrate-csv.sh
+++ b/migrate-csv.sh
@@ -34,6 +34,9 @@ while read source destination
 do
     # Remove carriage return from destination variable
     destination=$(echo $destination | sed 's/\r//g')
+    # Create target directory
+    mkdir -p $destination
+    # Move sample to destination and commit
 	echo -e "\n\xe2\x88\xb4 Moving ${GREEN}${source}${NC} to ${GREEN}${destination}${NC}\n"
     git mv $source $destination 
     git commit -m "move ${source} to ${destination}"

--- a/migrate-csv.sh
+++ b/migrate-csv.sh
@@ -30,12 +30,12 @@ do
    let count+=1
 done < $INPUT
 echo -e "\n${GREEN}Number of samples to be copied: ${count}${NC} \n---"
-exit 
 while read source destination
 do
+    # Remove carriage return from destination variable
     destination=$(echo $destination | sed 's/\r//g')
-	echo -e "\n\xe2\x88\xb4 moving ${source} to ${destination}"
-    git mv $source $destination
+	echo -e "\n\xe2\x88\xb4 Moving ${GREEN}${source}${NC} to ${GREEN}${destination}${NC}"
+    git mv $source $destination 
     git commit -m "move ${source} to ${destination}"
     saved=`git rev-parse HEAD`
     git reset --hard HEAD^

--- a/migrate-csv.sh
+++ b/migrate-csv.sh
@@ -35,7 +35,7 @@ do
     # Remove carriage return from destination variable
     destination=$(echo $destination | sed 's/\r//g')
     # Create target directory
-    mkdir -p $destination
+    mkdir -p $(dirname $destination)
     # Move sample to destination and commit
 	echo -e "\n\xe2\x88\xb4 Moving ${GREEN}${source}${NC} to ${GREEN}${destination}${NC}\n"
     git mv $source $destination 


### PR DESCRIPTION
This PR adds the following to the `migrate-csv.sh` script:
- formatting
- comments
- create subdirectories for non-existing destinations