### PR TITLE
chore: enable Vertex AI API for integration tests 

### DIFF
--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -37,6 +37,7 @@ module "projects" {
   auto_create_network = true
 
   activate_apis = [
+    "aiplatform.googleapis.com",
     "artifactregistry.googleapis.com",
     "bigquery.googleapis.com",
     "certificatemanager.googleapis.com",


### PR DESCRIPTION
Added aiplatform.googleapis.com to the activate_apis list to enable Vertex AI API for integration tests so individual samples won't need to enable the API by themselves. 