### PR TITLE
Fixed project id attribute in Cloud SQL IAM sample

### DIFF
--- a/cloud_sql/instance_iam_condition/main.tf
+++ b/cloud_sql/instance_iam_condition/main.tf
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+# Allow users to connect to specific Cloud SQL instances
+
 data "google_project" "project" {
 }
 

--- a/cloud_sql/instance_iam_condition/main.tf
+++ b/cloud_sql/instance_iam_condition/main.tf
@@ -30,7 +30,7 @@ data "google_iam_policy" "sql_iam_policy" {
       "serviceAccount:${google_project_service_identity.gcp_sa_cloud_sql.email}",
     ]
     condition {
-      expression  = "resource.name == 'projects/${data.google_project.project.id}/instances/${google_sql_database_instance.default.name}' && resource.type == 'sqladmin.googleapis.com/Instance'"
+      expression  = "resource.name == 'projects/${data.google_project.project.project_id}/instances/${google_sql_database_instance.default.name}' && resource.type == 'sqladmin.googleapis.com/Instance'"
       title       = "created"
       description = "Cloud SQL instance creation"
     }
@@ -38,7 +38,7 @@ data "google_iam_policy" "sql_iam_policy" {
 }
 
 resource "google_project_iam_policy" "project" {
-  project     = data.google_project.project.id
+  project     = data.google_project.project.project_id
   policy_data = data.google_iam_policy.sql_iam_policy.policy_data
 }
 # [END cloud_sql_instance_iam_conditions]


### PR DESCRIPTION
## Description

Fixes # b/262072140

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): https://cloud.google.com/sql/docs/mysql/iam-conditions 

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
