### PR TITLE
refactor: No need for google-beta

### DIFF
--- a/storage/make_data_public/main.tf
+++ b/storage/make_data_public/main.tf
@@ -19,7 +19,7 @@ resource "random_id" "bucket_prefix" {
 }
 
 resource "google_storage_bucket" "default" {
-  provider                    = google-beta
+  provider                    = google
   name                        = "${random_id.bucket_prefix.hex}-example-bucket-name"
   location                    = "US"
   uniform_bucket_level_access = true
@@ -28,7 +28,7 @@ resource "google_storage_bucket" "default" {
 # [START storage_make_data_public]
 # Make bucket public
 resource "google_storage_bucket_iam_member" "member" {
-  provider = google-beta
+  provider = google
   bucket   = google_storage_bucket.default.name
   role     = "roles/storage.objectViewer"
   member   = "allUsers"


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):https://cloud.google.com/storage/docs/access-control/making-data-public 

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
