### PR TITLE
chore: Updated region tags to support the sample browser

### DIFF
--- a/vertex_ai/dataset/main.tf
+++ b/vertex_ai/dataset/main.tf
@@ -15,34 +15,34 @@
  */
 
 
-# [START vertex_ai_dataset_image]
+# [START aiplatform_create_dataset_image_sample]
 resource "google_vertex_ai_dataset" "image_dataset" {
   display_name        = "image-dataset"
   metadata_schema_uri = "gs://google-cloud-aiplatform/schema/dataset/metadata/image_1.0.0.yaml"
   region              = "us-central1"
 }
-# [END vertex_ai_dataset_image]
+# [END aiplatform_create_dataset_image_sample]
 
-# [START vertex_ai_dataset_tabular]
+# [START aiplatform_create_dataset_tabular_sample]
 resource "google_vertex_ai_dataset" "tabular_dataset" {
   display_name        = "tabular-dataset"
   metadata_schema_uri = "gs://google-cloud-aiplatform/schema/dataset/metadata/tabular_1.0.0.yaml"
   region              = "us-central1"
 }
-# [END vertex_ai_dataset_tabular]
+# [END aiplatform_create_dataset_tabular_sample]
 
-# [START vertex_ai_dataset_text]
+# [START aiplatform_create_dataset_text_sample]
 resource "google_vertex_ai_dataset" "text_dataset" {
   display_name        = "text-dataset"
   metadata_schema_uri = "gs://google-cloud-aiplatform/schema/dataset/metadata/text_1.0.0.yaml"
   region              = "us-central1"
 }
-# [END vertex_ai_dataset_text]
+# [END aiplatform_create_dataset_text_sample]
 
-# [START vertex_ai_dataset_video]
+# [START aiplatform_create_dataset_video_sample]
 resource "google_vertex_ai_dataset" "video_dataset" {
   display_name        = "video-dataset"
   metadata_schema_uri = "gs://google-cloud-aiplatform/schema/dataset/metadata/video_1.0.0.yaml"
   region              = "us-central1"
 }
-# [END vertex_ai_dataset_video]
+# [END aiplatform_create_dataset_video_sample]

--- a/vertex_ai/dataset/test.yaml
+++ b/vertex_ai/dataset/test.yaml
@@ -15,6 +15,6 @@
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintTest
 metadata:
-  name: vertex_ai_dataset
+  name: dataset
 spec:
   skip: true

--- a/vertex_ai/endpoint/main.tf
+++ b/vertex_ai/endpoint/main.tf
@@ -19,12 +19,12 @@ provider "google" {
   region = "us-central1"
 }
 
+# [START aiplatform_create_endpoint_sample]
 # Endpoin name must be unique for the project
 resource "random_id" "endpoint_id" {
   byte_length = 4
 }
 
-# [START vertex_ai_endpoint]
 resource "google_vertex_ai_endpoint" "default" {
   name         = substr(random_id.endpoint_id.dec, 0, 10)
   display_name = "sample-endpoint"
@@ -34,5 +34,5 @@ resource "google_vertex_ai_endpoint" "default" {
     label-one = "value-one"
   }
 }
-# [END vertex_ai_endpoint]
+# [END aiplatform_create_endpoint_sample]
 

--- a/vertex_ai/featurestore/main.tf
+++ b/vertex_ai/featurestore/main.tf
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
+
+# [START aiplatform_create_featurestore_sample]
 # Featurestore name must be unique for the project
 resource "random_id" "featurestore_name_suffix" {
   byte_length = 8
 }
 
-# [START vertex_ai_featurestore]
 resource "google_vertex_ai_featurestore" "main" {
   name   = "featurestore_${random_id.featurestore_name_suffix.hex}"
   region = "us-central1"
@@ -33,4 +34,4 @@ resource "google_vertex_ai_featurestore" "main" {
 
   force_destroy = true
 }
-# [END vertex_ai_featurestore]
+# [END aiplatform_create_featurestore_sample]

--- a/vertex_ai/featurestore_entitytype/main.tf
+++ b/vertex_ai/featurestore_entitytype/main.tf
@@ -15,12 +15,12 @@
  */
 
 
+# [START aiplatform_create_featurestore_entitytype_sample]
 # Featurestore name must be unique for the project
 resource "random_id" "featurestore_name_suffix" {
   byte_length = 8
 }
 
-# [START vertex_ai_featurestore_entitytype]
 resource "google_vertex_ai_featurestore" "featurestore" {
   name   = "featurestore_${random_id.featurestore_name_suffix.hex}"
   region = "us-central1"
@@ -55,4 +55,4 @@ resource "google_vertex_ai_featurestore_entitytype" "entity" {
 
   depends_on = [google_vertex_ai_featurestore.featurestore]
 }
-# [END vertex_ai_featurestore_entitytype]
+# [END aiplatform_create_featurestore_entitytype_sample]

--- a/vertex_ai/index/main.tf
+++ b/vertex_ai/index/main.tf
@@ -15,6 +15,7 @@
  */
 
 
+# [START aiplatform_create_index_sample]
 # Cloud Storage bucket name must be unique
 resource "random_id" "bucket_name_suffix" {
   byte_length = 8
@@ -37,7 +38,6 @@ resource "google_storage_bucket_object" "data" {
 EOF
 }
 
-# [START vertex_ai_index]
 resource "google_vertex_ai_index" "default" {
   region       = "us-central1"
   display_name = "sample-index-batch-update"
@@ -67,4 +67,4 @@ resource "google_vertex_ai_index" "default" {
     update = "1h"
   }
 }
-# [END vertex_ai_index]
+# [END aiplatform_create_index_sample]

--- a/vertex_ai/managed_notebooks_runtime/main.tf
+++ b/vertex_ai/managed_notebooks_runtime/main.tf
@@ -15,7 +15,7 @@
  */
 
 
-# [START vertex_ai_managed_notebooks_runtime_basic]
+# [START aiplatform_create_managed_notebooks_runtime_sample]
 resource "google_notebooks_runtime" "basic_runtime" {
   name     = "notebooks-runtime-basic"
   location = "us-central1"
@@ -37,5 +37,5 @@ resource "google_notebooks_runtime" "basic_runtime" {
     }
   }
 }
-# [END vertex_ai_managed_notebooks_runtime_basic]
+# [END aiplatform_create_managed_notebooks_runtime_sample]
 

--- a/vertex_ai/metadata_store/main.tf
+++ b/vertex_ai/metadata_store/main.tf
@@ -15,15 +15,15 @@
  */
 
 
+# [START aiplatform_create_metadata_store_sample]
 resource "random_id" "store_prefix" {
   byte_length = 8
 }
 
-# [START vertex_ai_metadata_store]
 resource "google_vertex_ai_metadata_store" "main" {
   name        = "${random_id.store_prefix.hex}-test-store"
   description = "Example metadata store"
   provider    = google-beta
   region      = "us-central1"
 }
-# [END vertex_ai_metadata_store]
+# [END aiplatform_create_metadata_store_sample]

--- a/vertex_ai/tensorboard/main.tf
+++ b/vertex_ai/tensorboard/main.tf
@@ -15,9 +15,9 @@
  */
 
 
-# [START vertex_ai_tensorboard]
+# [START aiplatform_create_tensorboard_sample]
 resource "google_vertex_ai_tensorboard" "default" {
   display_name = "vertex-ai-tensorboard-sample-name"
   region       = "us-central1"
 }
-# [END vertex_ai_tensorboard]
+# [END aiplatform_create_tensorboard_sample]

--- a/vertex_ai/user_managed_notebooks_instance/main.tf
+++ b/vertex_ai/user_managed_notebooks_instance/main.tf
@@ -15,7 +15,7 @@
  */
 
 
-# [START vertex_ai_user_managed_notebooks_instance_basic]
+# [START aiplatform_create_user_managed_notebooks_instance_sample]
 resource "google_notebooks_instance" "basic_instance" {
   name         = "notebooks-instance-basic"
   location     = "us-central1-a"
@@ -26,4 +26,4 @@ resource "google_notebooks_instance" "basic_instance" {
     image_family = "tf-ent-2-9-cu113-notebooks"
   }
 }
-# [END vertex_ai_user_managed_notebooks_instance_basic]
+# [END aiplatform_create_user_managed_notebooks_instance_sample]


### PR DESCRIPTION
## Description

Fixes #279425203

Updated region tags for Vertex AI samples to support the sample browser.
Cleaned up samples to make samples standalone.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [ ] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [ ] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [ ] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [ ] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [ ] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
