### PR TITLE
feat(Cloud Storage): Add bucket encryption sample

### DIFF
--- a/storage/flask_google_cloud_quickstart/main.tf
+++ b/storage/flask_google_cloud_quickstart/main.tf
@@ -91,7 +91,7 @@ resource "google_compute_firewall" "flask" {
 
 # [START storage_kms_encryption_tfstate]
 resource "google_kms_key_ring" "terraform_state" {
-  name     = "test-terraform-state"
+  name     = "${random_id.bucket_prefix.hex}-bucket-tfstate"
   location = "us"
 }
 
@@ -109,7 +109,7 @@ resource "google_kms_crypto_key" "terraform_state_bucket" {
 data "google_project" "project" {
 }
 
-resource "google_project_iam_member" "grant_google_storage_service_encrypt_decrypt" {
+resource "google_project_iam_member" "default" {
   project = data.google_project.project.project_id
   role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   member  = "serviceAccount:service-${data.google_project.project.number}@gs-project-accounts.iam.gserviceaccount.com"

--- a/storage/flask_google_cloud_quickstart/main.tf
+++ b/storage/flask_google_cloud_quickstart/main.tf
@@ -89,6 +89,33 @@ resource "google_compute_firewall" "flask" {
 # Create new multi-region storage bucket in the US
 # with versioning enabled
 
+# [START storage_kms_encryption_tfstate]
+resource "google_kms_key_ring" "terraform_state" {
+  name     = "test-terraform-state"
+  location = "us"
+}
+
+resource "google_kms_crypto_key" "terraform_state_bucket" {
+  name            = "test-terraform-state-bucket"
+  key_ring        = "${google_kms_key_ring.terraform_state.id}"
+  rotation_period = "86400s"
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+# Enable the Cloud Storage service account to encrypt/decrypt Cloud KMS keys
+data "google_project" "project" {
+}
+
+resource "google_project_iam_member" "grant_google_storage_service_encrypt_decrypt" {
+  project = data.google_project.project.project_id
+  role       = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member     = "serviceAccount:service-${data.google_project.project.number}@gs-project-accounts.iam.gserviceaccount.com"
+}
+# [END storage_kms_encryption_tfstate]
+
 # [START storage_bucket_tf_with_versioning]
 resource "random_id" "bucket_prefix" {
   byte_length = 8
@@ -101,6 +128,9 @@ resource "google_storage_bucket" "default" {
   storage_class = "STANDARD"
   versioning {
     enabled = true
+  }
+  encryption {
+    default_kms_key_name = google_kms_crypto_key.terraform_state_bucket.id
   }
 }
 # [END storage_bucket_tf_with_versioning]

--- a/storage/flask_google_cloud_quickstart/main.tf
+++ b/storage/flask_google_cloud_quickstart/main.tf
@@ -97,7 +97,7 @@ resource "google_kms_key_ring" "terraform_state" {
 
 resource "google_kms_crypto_key" "terraform_state_bucket" {
   name            = "test-terraform-state-bucket"
-  key_ring        = "${google_kms_key_ring.terraform_state.id}"
+  key_ring        = google_kms_key_ring.terraform_state.id
   rotation_period = "86400s"
 
   lifecycle {
@@ -111,8 +111,8 @@ data "google_project" "project" {
 
 resource "google_project_iam_member" "grant_google_storage_service_encrypt_decrypt" {
   project = data.google_project.project.project_id
-  role       = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member     = "serviceAccount:service-${data.google_project.project.number}@gs-project-accounts.iam.gserviceaccount.com"
+  role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member  = "serviceAccount:service-${data.google_project.project.number}@gs-project-accounts.iam.gserviceaccount.com"
 }
 # [END storage_kms_encryption_tfstate]
 

--- a/storage/flask_google_cloud_quickstart/main.tf
+++ b/storage/flask_google_cloud_quickstart/main.tf
@@ -132,6 +132,9 @@ resource "google_storage_bucket" "default" {
   encryption {
     default_kms_key_name = google_kms_crypto_key.terraform_state_bucket.id
   }
+  depends_on = [
+    google_project_iam_member.default
+  ]
 }
 # [END storage_bucket_tf_with_versioning]
 # [END storage_flask_google_cloud_quickstart_parent_tag]

--- a/storage/flask_google_cloud_quickstart/test.yaml
+++ b/storage/flask_google_cloud_quickstart/test.yaml
@@ -1,0 +1,20 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintTest
+metadata:
+  name: flask_google_cloud_quickstart
+spec:
+  skip: true


### PR DESCRIPTION
## Description

Fixes # b/284014407

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): https://cloud.google.com/docs/terraform/resource-management/store-state

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
