### PR TITLE
fix: add documentation for local SSD

### DIFF
--- a/compute/basic_vm/main.tf
+++ b/compute/basic_vm/main.tf
@@ -75,3 +75,26 @@ resource "google_compute_instance" "custom_subnet" {
 }
 # [END compute_instances_create_with_subnet]
 # [END compute_basic_vm_parent_tag]
+
+# [START compute_instances_create_with_local_ssd]
+
+# Create a VM with a local SSD for temporary storage use cases
+
+resource "google_compute_instance" "default" {
+    name = "my-vm-instance-with-scratch"
+    machine_type = "n2-standard-8" 
+    zone = "us-central1-a" 
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  // Local SSD interface type; NVME for image with optimized NVMe drivers or SCSI
+  scratch_disk {
+    interface = "SCSI"
+  }
+}
+
+# [END compute_instances_create_with_local_ssd]


### PR DESCRIPTION
fixes issue #449 for @janetstern 

provides Terraform option for https://cloud.google.com/compute/docs/disks/add-local-ssd#gcloud 

Uses region tag as per that page; n2-standard-8 to match gcloud option as per the above page

## Description

Fixes #<ISSUE-NUMBER>

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [X] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [ ] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [ ] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [ ] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [ ] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [X] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):https://cloud.google.com/compute/docs/disks/add-local-ssd#gcloud 

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
