### PR TITLE
feat: update Cloud Run services to google_cloud_run_v2_service

### DIFF
--- a/run/access_control/main.tf
+++ b/run/access_control/main.tf
@@ -16,29 +16,22 @@
 
 # [START cloudrun_access_control_parent_tag]
 # [START cloudrun_service_access_control_run_service]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloud-run-srv"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        image = "gcr.io/cloudrun/hello"
-      }
+    containers {
+      image = "gcr.io/cloudrun/hello"
     }
-  }
-
-  traffic {
-    percent         = 100
-    latest_revision = true
   }
 }
 # [END cloudrun_service_access_control_run_service]
 
 # [START cloudrun_service_access_control_iam_binding]
 resource "google_cloud_run_service_iam_binding" "default" {
-  location = google_cloud_run_service.default.location
-  service  = google_cloud_run_service.default.name
+  location = google_cloud_run_v2_service.default.location
+  service  = google_cloud_run_v2_service.default.name
   role     = "roles/run.invoker"
   members = [
     "allUsers"

--- a/run/add_tag/main.tf
+++ b/run/add_tag/main.tf
@@ -21,6 +21,8 @@ resource "google_cloud_run_v2_service" "default" {
 
   template {}
 
+  # Define the traffic split for each revision
+  # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#traffic
   traffic {
     percent = 100
     # This revision needs to already exist

--- a/run/add_tag/main.tf
+++ b/run/add_tag/main.tf
@@ -15,7 +15,7 @@
  */
 
 # [START cloudrun_service_add_tag]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-srv"
   location = "us-central1"
 
@@ -24,14 +24,16 @@ resource "google_cloud_run_service" "default" {
   traffic {
     percent = 100
     # This revision needs to already exist
-    revision_name = "cloudrun-srv-green"
+    revision = "cloudrun-srv-green"
+    type     = "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"
   }
 
   traffic {
     # Deploy new revision with 0% traffic
-    percent       = 0
-    revision_name = "cloudrun-srv-blue"
-    tag           = "tag-name"
+    percent  = 0
+    revision = "cloudrun-srv-blue"
+    tag      = "tag-name"
+    type     = "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"
   }
 }
 # [END cloudrun_service_add_tag]

--- a/run/connect_cloud_sql/main.tf
+++ b/run/connect_cloud_sql/main.tf
@@ -141,61 +141,53 @@ resource "google_secret_manager_secret_iam_member" "secretaccess_compute_dbname"
 
 
 # [START cloudrun_service_cloudsql_default_service]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-service"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        image = "us-docker.pkg.dev/cloudrun/container/hello:latest" # Image to deploy
-        # Sets a environment variable for instance connection name
-        env {
-          name  = "INSTANCE_CONNECTION_NAME"
-          value = google_sql_database_instance.mysql_instance.connection_name
-        }
-        # Sets a secret environment variable for database user secret
-        env {
-          name = "DB_USER"
-          value_from {
-            secret_key_ref {
-              name = google_secret_manager_secret.dbuser.secret_id # secret name
-              key  = "latest"                                      # secret version number or 'latest'
-            }
-          }
-        }
-        # Sets a secret environment variable for database password secret
-        env {
-          name = "DB_PASS"
-          value_from {
-            secret_key_ref {
-              name = google_secret_manager_secret.dbpass.secret_id # secret name
-              key  = "latest"                                      # secret version number or 'latest'
-            }
-          }
-        }
-        # Sets a secret environment variable for database name secret
-        env {
-          name = "DB_NAME"
-          value_from {
-            secret_key_ref {
-              name = google_secret_manager_secret.dbname.secret_id # secret name
-              key  = "latest"                                      # secret version number or 'latest'
-            }
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello:latest" # Image to deploy
+      # Sets a environment variable for instance connection name
+      env {
+        name  = "INSTANCE_CONNECTION_NAME"
+        value = google_sql_database_instance.mysql_instance.connection_name
+      }
+      # Sets a secret environment variable for database user secret
+      env {
+        name = "DB_USER"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.dbuser.secret_id # secret name
+            version = "latest"                                      # secret version number or 'latest'
           }
         }
       }
-    }
-
-    metadata {
-      annotations = {
-        "run.googleapis.com/client-name" = "terraform"
+      # Sets a secret environment variable for database password secret
+      env {
+        name = "DB_PASS"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.dbpass.secret_id # secret name
+            version = "latest"                                      # secret version number or 'latest'
+          }
+        }
+      }
+      # Sets a secret environment variable for database name secret
+      env {
+        name = "DB_NAME"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.dbname.secret_id # secret name
+            version = "latest"                                      # secret version number or 'latest'
+          }
+        }
       }
     }
   }
 
-  autogenerate_revision_name = true
-  depends_on                 = [google_project_service.secretmanager_api, google_project_service.cloudrun_api, google_project_service.sqladmin_api]
+  client     = "terraform"
+  depends_on = [google_project_service.secretmanager_api, google_project_service.cloudrun_api, google_project_service.sqladmin_api]
 }
 # [END cloudrun_service_cloudsql_default_service]
 # [END cloudrun_connect_cloud_sql_parent_tag]

--- a/run/custom_domain_mapping/main.tf
+++ b/run/custom_domain_mapping/main.tf
@@ -16,19 +16,13 @@
 
 # [START cloudrun_custom_domain_mapping_parent_tag]
 # [START cloudrun_custom_domain_mapping_run_service]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloud-run-srv"
   location = "us-central1"
   template {
-    spec {
-      containers {
-        image = "gcr.io/cloudrun/hello"
-      }
+    containers {
+      image = "gcr.io/cloudrun/hello"
     }
-  }
-  traffic {
-    percent         = 100
-    latest_revision = true
   }
 }
 # [END cloudrun_custom_domain_mapping_run_service]
@@ -37,12 +31,12 @@ data "google_project" "project" {}
 
 resource "google_cloud_run_domain_mapping" "default" {
   name     = "verified-domain.com"
-  location = google_cloud_run_service.default.location
+  location = google_cloud_run_v2_service.default.location
   metadata {
     namespace = data.google_project.project.project_id
   }
   spec {
-    route_name = google_cloud_run_service.default.name
+    route_name = google_cloud_run_v2_service.default.name
   }
 }
 # [END cloudrun_custom_domain_mapping]

--- a/run/deploy_tag/main.tf
+++ b/run/deploy_tag/main.tf
@@ -27,6 +27,8 @@ resource "google_cloud_run_v2_service" "default" {
     revision = "cloudrun-srv-blue"
   }
 
+  # Define the traffic split for each revision
+  # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#traffic
   traffic {
     percent = 100
     # This revision needs to already exist

--- a/run/deploy_tag/main.tf
+++ b/run/deploy_tag/main.tf
@@ -15,33 +15,31 @@
  */
 
 # [START cloudrun_service_deploy_tag]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-srv"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        # image or tag must be different from previous revision
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
-      }
+    containers {
+      # image or tag must be different from previous revision
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
     }
-    metadata {
-      name = "cloudrun-srv-blue"
-    }
+    revision = "cloudrun-srv-blue"
   }
 
   traffic {
     percent = 100
     # This revision needs to already exist
-    revision_name = "cloudrun-srv-green"
+    revision = "cloudrun-srv-green"
+    type     = "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"
   }
 
   traffic {
     # Deploy new revision with 0% traffic
-    percent       = 0
-    revision_name = "cloudrun-srv-blue"
-    tag           = "tag-name"
+    percent  = 0
+    revision = "cloudrun-srv-blue"
+    tag      = "tag-name"
+    type     = "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"
   }
 }
 # [END cloudrun_service_deploy_tag]

--- a/run/healthchecks_liveness_probe_grpc/main.tf
+++ b/run/healthchecks_liveness_probe_grpc/main.tf
@@ -26,35 +26,28 @@ resource "google_project_service" "cloudrun_api" {
 
 # Create Cloud Run Container with gRPC liveness probe
 #[START cloud_run_healthchecks_liveness_probe_gRPC]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   provider = google-beta
   name     = "cloudrun-service-healthcheck"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        # Note: Change to the name of your image
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
+    containers {
+      # Note: Change to the name of your image
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
 
-        liveness_probe {
-          failure_threshold     = 5
-          initial_delay_seconds = 10
-          timeout_seconds       = 3
-          period_seconds        = 3
+      liveness_probe {
+        failure_threshold     = 5
+        initial_delay_seconds = 10
+        timeout_seconds       = 3
+        period_seconds        = 3
 
-          # Note: Change to the name of your pre-existing grpc health status service
-          grpc {
-            service = "grpc.health.v1.Health"
-          }
+        # Note: Change to the name of your pre-existing grpc health status service
+        grpc {
+          service = "grpc.health.v1.Health"
         }
       }
     }
-  }
-
-  traffic {
-    percent         = 100
-    latest_revision = true
   }
 }
 #[END cloud_run_healthchecks_liveness_probe_gRPC]

--- a/run/healthchecks_liveness_probe_http/main.tf
+++ b/run/healthchecks_liveness_probe_http/main.tf
@@ -26,37 +26,30 @@ resource "google_project_service" "cloudrun_api" {
 
 # Create Cloud Run Container with HTTP liveness probe
 #[START cloud_run_healthchecks_liveness_probe_http]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   provider = google-beta
   name     = "cloudrun-service-healthcheck"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
 
-        liveness_probe {
-          failure_threshold     = 5
-          initial_delay_seconds = 10
-          timeout_seconds       = 3
-          period_seconds        = 3
+      liveness_probe {
+        failure_threshold     = 5
+        initial_delay_seconds = 10
+        timeout_seconds       = 3
+        period_seconds        = 3
 
-          http_get {
-            path = "/"
-            http_headers {
-              name  = "Access-Control-Allow-Origin"
-              value = "*"
-            }
+        http_get {
+          path = "/"
+          http_headers {
+            name  = "Access-Control-Allow-Origin"
+            value = "*"
           }
         }
       }
     }
-  }
-
-  traffic {
-    percent         = 100
-    latest_revision = true
   }
 }
 #[END cloud_run_healthchecks_liveness_probe_http]

--- a/run/healthchecks_liveness_probe_http/main.tf
+++ b/run/healthchecks_liveness_probe_http/main.tf
@@ -43,6 +43,8 @@ resource "google_cloud_run_v2_service" "default" {
 
         http_get {
           path = "/"
+          # Custom headers to set in the request
+          # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#http_headers
           http_headers {
             name  = "Access-Control-Allow-Origin"
             value = "*"

--- a/run/healthchecks_startup_probe_http/main.tf
+++ b/run/healthchecks_startup_probe_http/main.tf
@@ -26,37 +26,30 @@ resource "google_project_service" "cloudrun_api" {
 
 # Create Cloud Run Container with HTTP startup probe
 #[START cloud_run_healthchecks_startup_probe_http]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   provider = google-beta
   name     = "cloudrun-service-healthcheck"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
 
-        startup_probe {
-          failure_threshold     = 5
-          initial_delay_seconds = 10
-          timeout_seconds       = 3
-          period_seconds        = 3
+      startup_probe {
+        failure_threshold     = 5
+        initial_delay_seconds = 10
+        timeout_seconds       = 3
+        period_seconds        = 3
 
-          http_get {
-            path = "/"
-            http_headers {
-              name  = "Access-Control-Allow-Origin"
-              value = "*"
-            }
+        http_get {
+          path = "/"
+          http_headers {
+            name  = "Access-Control-Allow-Origin"
+            value = "*"
           }
         }
       }
     }
-  }
-
-  traffic {
-    percent         = 100
-    latest_revision = true
   }
 }
 #[END cloud_run_healthchecks_startup_probe_http]

--- a/run/healthchecks_startup_probe_http/main.tf
+++ b/run/healthchecks_startup_probe_http/main.tf
@@ -43,6 +43,8 @@ resource "google_cloud_run_v2_service" "default" {
 
         http_get {
           path = "/"
+          # Custom headers to set in the request
+          # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#http_headers
           http_headers {
             name  = "Access-Control-Allow-Origin"
             value = "*"

--- a/run/healthchecks_startup_probe_tcp/main.tf
+++ b/run/healthchecks_startup_probe_tcp/main.tf
@@ -26,33 +26,26 @@ resource "google_project_service" "cloudrun_api" {
 
 # Create Cloud Run Container with TCP startup probe
 #[START cloud_run_healthchecks_startup_probe_tcp]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   provider = google-beta
   name     = "cloudrun-service-healthcheck"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
 
-        startup_probe {
-          failure_threshold     = 5
-          initial_delay_seconds = 10
-          timeout_seconds       = 3
-          period_seconds        = 3
+      startup_probe {
+        failure_threshold     = 5
+        initial_delay_seconds = 10
+        timeout_seconds       = 3
+        period_seconds        = 3
 
-          tcp_socket {
-            port = 8080
-          }
+        tcp_socket {
+          port = 8080
         }
       }
     }
-  }
-
-  traffic {
-    percent         = 100
-    latest_revision = true
   }
 }
 #[END cloud_run_healthchecks_startup_probe_tcp]

--- a/run/identity/main.tf
+++ b/run/identity/main.tf
@@ -22,22 +22,15 @@ resource "google_service_account" "cloudrun_service_identity" {
 # [END cloudrun_service_identity_iam]
 
 # [START cloudrun_service_identity_run_service]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloud-run-srv"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        image = "gcr.io/cloudrun/hello"
-      }
-      service_account_name = google_service_account.cloudrun_service_identity.email
+    containers {
+      image = "gcr.io/cloudrun/hello"
     }
-  }
-
-  traffic {
-    percent         = 100
-    latest_revision = true
+    service_account = google_service_account.cloudrun_service_identity.email
   }
 }
 # [END cloudrun_service_identity_run_service]

--- a/run/image_processing/main.tf
+++ b/run/image_processing/main.tf
@@ -93,6 +93,8 @@ resource "google_cloud_run_v2_service" "default" {
   location = "us-central1"
   template {
     containers {
+
+      # Replace with newly created image gcr.io/<project_id>/pubsub
       image = "gcr.io/cloudrun/hello"
       env {
         name  = "BLURRED_BUCKET_NAME"

--- a/run/image_processing/main.tf
+++ b/run/image_processing/main.tf
@@ -22,8 +22,8 @@ resource "google_service_account" "sa" {
 }
 
 resource "google_cloud_run_service_iam_binding" "binding" {
-  location = google_cloud_run_service.default.location
-  service  = google_cloud_run_service.default.name
+  location = google_cloud_run_v2_service.default.location
+  service  = google_cloud_run_v2_service.default.name
   role     = "roles/run.invoker"
   members  = ["serviceAccount:${google_service_account.sa.email}"]
 }
@@ -51,7 +51,7 @@ resource "google_pubsub_subscription" "subscription" {
   name  = "pubsub_subscription"
   topic = google_pubsub_topic.default.name
   push_config {
-    push_endpoint = google_cloud_run_service.default.status[0].url
+    push_endpoint = google_cloud_run_v2_service.default.uri
     oidc_token {
       service_account_email = google_service_account.sa.email
     }
@@ -88,23 +88,17 @@ output "blurred_bucket_name" {
 # [END cloudrun_service_image_processing_buckets]
 
 # [START cloudrun_service_image_processing_crservice]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "pubsub-tutorial"
   location = "us-central1"
   template {
-    spec {
-      containers {
-        image = "gcr.io/cloudrun/hello"
-        env {
-          name  = "BLURRED_BUCKET_NAME"
-          value = google_storage_bucket.imageproc_output.name
-        }
+    containers {
+      image = "gcr.io/cloudrun/hello"
+      env {
+        name  = "BLURRED_BUCKET_NAME"
+        value = google_storage_bucket.imageproc_output.name
       }
     }
-  }
-  traffic {
-    percent         = 100
-    latest_revision = true
   }
 }
 # [END cloudrun_service_image_processing_crservice]

--- a/run/ingress/main.tf
+++ b/run/ingress/main.tf
@@ -40,6 +40,7 @@ resource "google_cloud_run_v2_service" "default" {
     }
   }
   # [END cloudrun_service_ingress]
+  # Used in sample testing. These fields may change in 'terraform plan' output, which is expected and thus non-blocking.
   lifecycle {
     ignore_changes = [
       ingress

--- a/run/ingress/main.tf
+++ b/run/ingress/main.tf
@@ -25,34 +25,26 @@ resource "google_project_service" "cloudrun_api" {
 }
 
 # [START cloudrun_service_ingress]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   provider = google-beta
   name     = "ingress-service"
   location = "us-central1"
 
-  template {
-    spec {
-      containers {
-        image = "gcr.io/cloudrun/hello" #public image for your service
-      }
-    }
-  }
-  traffic {
-    percent         = 100
-    latest_revision = true
-  }
-  metadata {
-    annotations = {
-      # For valid annotation values and descriptions, see
-      # https://cloud.google.com/sdk/gcloud/reference/run/deploy#--ingress
-      "run.googleapis.com/ingress" = "internal"
-    }
-  }
+  # For valid annotation values and descriptions, see
+  # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#ingress
+  ingress = "INGRESS_TRAFFIC_INTERNAL_ONLY"
 
+  template {
+    containers {
+      image = "gcr.io/cloudrun/hello" #public image for your service
+    }
+  }
+  # [END cloudrun_service_ingress]
   lifecycle {
     ignore_changes = [
-      metadata[0].annotations,
+      ingress
     ]
   }
+  # [START cloudrun_service_ingress]
 }
 # [END cloudrun_service_ingress]

--- a/run/interservice/main.tf
+++ b/run/interservice/main.tf
@@ -18,29 +18,26 @@
 
 # [START cloudrun_interservice_parent_tag]
 # [START cloudrun_service_interservice_public_service]
-resource "google_cloud_run_service" "public" {
+resource "google_cloud_run_v2_service" "public" {
   name     = "public-service"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        # TODO<developer>: replace this with a public service container
-        # (This service can be invoked by anyone on the internet)
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
+    containers {
+      # TODO<developer>: replace this with a public service container
+      # (This service can be invoked by anyone on the internet)
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
 
-        # Include a reference to the private Cloud Run
-        # service's URL as an environment variable.
-        env {
-          name  = "URL"
-          value = google_cloud_run_service.private.status[0].url
-        }
+      # Include a reference to the private Cloud Run
+      # service's URL as an environment variable.
+      env {
+        name  = "URL"
+        value = google_cloud_run_v2_service.private.uri
       }
-
-      # Give the "public" Cloud Run service
-      # a service account's identity
-      service_account_name = google_service_account.default.email
     }
+    # Give the "public" Cloud Run service
+    # a service account's identity
+    service_account = google_service_account.default.email
   }
 }
 # [END cloudrun_service_interservice_public_service]
@@ -56,9 +53,9 @@ data "google_iam_policy" "public" {
 }
 
 resource "google_cloud_run_service_iam_policy" "public" {
-  location = google_cloud_run_service.public.location
-  project  = google_cloud_run_service.public.project
-  service  = google_cloud_run_service.public.name
+  location = google_cloud_run_v2_service.public.location
+  project  = google_cloud_run_v2_service.public.project
+  service  = google_cloud_run_v2_service.public.name
 
   policy_data = data.google_iam_policy.public.policy_data
 }
@@ -73,17 +70,15 @@ resource "google_service_account" "default" {
 # [END cloudrun_service_interservice_sa]
 
 # [START cloudrun_service_interservice_private_service]
-resource "google_cloud_run_service" "private" {
+resource "google_cloud_run_v2_service" "private" {
   name     = "private-service"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        // TODO<developer>: replace this with a private service container
-        // (This service should only be invocable by the public service)
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
-      }
+    containers {
+      // TODO<developer>: replace this with a private service container
+      // (This service should only be invocable by the public service)
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
     }
   }
 }
@@ -100,9 +95,9 @@ data "google_iam_policy" "private" {
 }
 
 resource "google_cloud_run_service_iam_policy" "private" {
-  location = google_cloud_run_service.private.location
-  project  = google_cloud_run_service.private.project
-  service  = google_cloud_run_service.private.name
+  location = google_cloud_run_v2_service.private.location
+  project  = google_cloud_run_v2_service.private.project
+  service  = google_cloud_run_v2_service.private.name
 
   policy_data = data.google_iam_policy.private.policy_data
 }

--- a/run/multiple_regions/main.tf
+++ b/run/multiple_regions/main.tf
@@ -141,7 +141,7 @@ resource "google_compute_region_network_endpoint_group" "lb_default" {
   network_endpoint_type = "SERVERLESS"
   region                = var.run_regions[count.index]
   cloud_run {
-    service = google_cloud_run_service.run_default[count.index].name
+    service = google_cloud_run_v2_service.run_default[count.index].name
   }
 }
 # [END cloudrun_multiregion_neg]
@@ -153,23 +153,16 @@ output "load_balancer_ip_addr" {
 # [END cloudrun_multiregion_addr]
 
 # [START cloudrun_multiregion_service]
-resource "google_cloud_run_service" "run_default" {
+resource "google_cloud_run_v2_service" "run_default" {
   provider = google-beta
   count    = length(var.run_regions)
   name     = "myservice-run-app-${var.run_regions[count.index]}"
   location = var.run_regions[count.index]
 
   template {
-    spec {
-      containers {
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
-      }
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
     }
-  }
-
-  traffic {
-    percent         = 100
-    latest_revision = true
   }
 
   # Use an explicit depends_on clause to wait until API is enabled
@@ -183,8 +176,8 @@ resource "google_cloud_run_service" "run_default" {
 resource "google_cloud_run_service_iam_member" "run_allow_unauthenticated" {
   provider = google-beta
   count    = length(var.run_regions)
-  location = google_cloud_run_service.run_default[count.index].location
-  service  = google_cloud_run_service.run_default[count.index].name
+  location = google_cloud_run_v2_service.run_default[count.index].location
+  service  = google_cloud_run_v2_service.run_default[count.index].name
   role     = "roles/run.invoker"
   member   = "allUsers"
 }

--- a/run/noauth/main.tf
+++ b/run/noauth/main.tf
@@ -18,15 +18,13 @@
 
 # [START cloudrun_noauth_parent_tag]
 # [START cloudrun_service_noauth]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-srv"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
-      }
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
     }
   }
 }
@@ -43,9 +41,9 @@ data "google_iam_policy" "noauth" {
 }
 
 resource "google_cloud_run_service_iam_policy" "noauth" {
-  location = google_cloud_run_service.default.location
-  project  = google_cloud_run_service.default.project
-  service  = google_cloud_run_service.default.name
+  location = google_cloud_run_v2_service.default.location
+  project  = google_cloud_run_v2_service.default.project
+  service  = google_cloud_run_v2_service.default.name
 
   policy_data = data.google_iam_policy.noauth.policy_data
 }

--- a/run/pubsub/main.tf
+++ b/run/pubsub/main.tf
@@ -25,19 +25,13 @@ resource "google_project_service" "cloudrun_api" {
 }
 
 # [START cloudrun_service_pubsub_service]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "pubsub-tutorial"
   location = "us-central1"
   template {
-    spec {
-      containers {
-        image = "gcr.io/cloudrun/hello" # Replace with newly created image gcr.io/<project_id>/pubsub
-      }
+    containers {
+      image = "gcr.io/cloudrun/hello" # Replace with newly created image gcr.io/<project_id>/pubsub
     }
-  }
-  traffic {
-    percent         = 100
-    latest_revision = true
   }
   depends_on = [google_project_service.cloudrun_api]
 }
@@ -52,8 +46,8 @@ resource "google_service_account" "sa" {
 
 # [START cloudrun_service_pubsub_run_invoke_permissions]
 resource "google_cloud_run_service_iam_binding" "binding" {
-  location = google_cloud_run_service.default.location
-  service  = google_cloud_run_service.default.name
+  location = google_cloud_run_v2_service.default.location
+  service  = google_cloud_run_v2_service.default.name
   role     = "roles/run.invoker"
   members  = ["serviceAccount:${google_service_account.sa.email}"]
 }
@@ -84,7 +78,7 @@ resource "google_pubsub_subscription" "subscription" {
   name  = "pubsub_subscription"
   topic = google_pubsub_topic.default.name
   push_config {
-    push_endpoint = google_cloud_run_service.default.status[0].url
+    push_endpoint = google_cloud_run_v2_service.default.uri
     oidc_token {
       service_account_email = google_service_account.sa.email
     }
@@ -92,7 +86,7 @@ resource "google_pubsub_subscription" "subscription" {
       x-goog-version = "v1"
     }
   }
-  depends_on = [google_cloud_run_service.default]
+  depends_on = [google_cloud_run_v2_service.default]
 }
 # [END cloudrun_service_pubsub_sub]
 # [END cloudrun_pubsub_parent_tag]

--- a/run/remove_tag/main.tf
+++ b/run/remove_tag/main.tf
@@ -15,7 +15,7 @@
  */
 
 # [START cloudrun_service_remove_tag]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-srv"
   location = "us-central1"
 
@@ -24,7 +24,9 @@ resource "google_cloud_run_service" "default" {
   traffic {
     percent = 100
     # This revision needs to already exist
-    revision_name = "cloudrun-srv-green"
+    revision = "cloudrun-srv-green"
+    type     = "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"
+
 
   }
   traffic {
@@ -32,7 +34,8 @@ resource "google_cloud_run_service" "default" {
     # Keep revision at 0% traffic
     percent = 0
     # This revision needs to already exist
-    revision_name = "cloudrun-srv-blue"
+    revision = "cloudrun-srv-blue"
+    type     = "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"
   }
 }
 # [END cloudrun_service_remove_tag]

--- a/run/remove_tag/main.tf
+++ b/run/remove_tag/main.tf
@@ -21,14 +21,15 @@ resource "google_cloud_run_v2_service" "default" {
 
   template {}
 
+  # Define the traffic split for each revision
+  # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#traffic
   traffic {
     percent = 100
     # This revision needs to already exist
     revision = "cloudrun-srv-green"
     type     = "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"
-
-
   }
+
   traffic {
     # No tags for this revision
     # Keep revision at 0% traffic

--- a/run/static_outbound/main.tf
+++ b/run/static_outbound/main.tf
@@ -131,6 +131,7 @@ resource "google_cloud_run_v2_service" "default" {
   ingress = "INGRESS_TRAFFIC_ALL"
 
   # [END cloudrun_service_static_service]
+  # Used in sample testing. These fields may change in 'terraform plan' output, which is expected and thus non-blocking.
   lifecycle {
     ignore_changes = [
       ingress, template[0].vpc_access

--- a/run/system_packages/main.tf
+++ b/run/system_packages/main.tf
@@ -23,25 +23,18 @@ resource "google_service_account" "graphviz" {
   display_name = "GraphViz Tutorial Service Account"
 }
 
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "graphviz-example"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        # Replace with the URL of your graphviz image
-        #   gcr.io/<YOUR_GCP_PROJECT_ID>/graphviz
-        image = "gcr.io/cloudrun/hello"
-      }
-
-      service_account_name = google_service_account.graphviz.email
+    containers {
+      # Replace with the URL of your graphviz image
+      #   gcr.io/<YOUR_GCP_PROJECT_ID>/graphviz
+      image = "gcr.io/cloudrun/hello"
     }
-  }
 
-  traffic {
-    percent         = 100
-    latest_revision = true
+    service_account = google_service_account.graphviz.email
   }
 }
 # [END cloudrun_system_packages]
@@ -49,8 +42,8 @@ resource "google_cloud_run_service" "default" {
 # [START cloudrun_system_packages_allow_unauthenticated]
 # Make Cloud Run service publicly accessible
 resource "google_cloud_run_service_iam_member" "allow_unauthenticated" {
-  service  = google_cloud_run_service.default.name
-  location = google_cloud_run_service.default.location
+  service  = google_cloud_run_v2_service.default.name
+  location = google_cloud_run_v2_service.default.location
   role     = "roles/run.invoker"
   member   = "allUsers"
 }

--- a/run/tasks/main.tf
+++ b/run/tasks/main.tf
@@ -16,20 +16,14 @@
 
 # [START cloudrun_tasks_parent_tag]
 # [START cloudrun_service_tasks_service]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloud-run-service-name"
   location = "us-central1"
   provider = google-beta
   template {
-    spec {
-      containers {
-        image = "gcr.io/cloudrun/hello"
-      }
+    containers {
+      image = "gcr.io/cloudrun/hello"
     }
-  }
-  traffic {
-    percent         = 100
-    latest_revision = true
   }
 }
 # [END cloudrun_service_tasks_service]
@@ -44,12 +38,12 @@ resource "google_service_account" "sa" {
 
 # [START cloudrun_service_tasks_run_invoke_permissions]
 resource "google_cloud_run_service_iam_binding" "binding" {
-  location = google_cloud_run_service.default.location
-  service  = google_cloud_run_service.default.name
+  location = google_cloud_run_v2_service.default.location
+  service  = google_cloud_run_v2_service.default.name
   role     = "roles/run.invoker"
   members  = ["serviceAccount:${google_service_account.sa.email}"]
   provider = google-beta
-  project  = google_cloud_run_service.default.project
+  project  = google_cloud_run_v2_service.default.project
 }
 # [END cloudrun_service_tasks_run_invoke_permissions]
 
@@ -58,7 +52,7 @@ resource "google_project_iam_binding" "project_binding" {
   role     = "roles/iam.serviceAccountTokenCreator"
   members  = ["serviceAccount:${google_service_account.sa.email}"]
   provider = google-beta
-  project  = google_cloud_run_service.default.project
+  project  = google_cloud_run_v2_service.default.project
 }
 # [END cloudrun_service_tasks_token_permissions]
 

--- a/run/traffic_gradual_rollout/main.tf
+++ b/run/traffic_gradual_rollout/main.tf
@@ -26,6 +26,8 @@ resource "google_cloud_run_v2_service" "default" {
     }
   }
 
+  # Define the traffic split for each revision
+  # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#traffic
   traffic {
     percent = 100
     # This revision needs to already exist

--- a/run/traffic_gradual_rollout/main.tf
+++ b/run/traffic_gradual_rollout/main.tf
@@ -15,31 +15,28 @@
  */
 
 # [START cloudrun_service_traffic_gradual_rollout]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-srv"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        # Image or image tag must be different from previous revision
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
-      }
+    containers {
+      # Image or image tag must be different from previous revision
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
     }
   }
-  autogenerate_revision_name = true
 
   traffic {
     percent = 100
     # This revision needs to already exist
-    revision_name = "cloudrun-srv-green"
-
+    revision = "cloudrun-srv-green"
+    type     = "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"
   }
 
   traffic {
     # Deploy new revision with 0% traffic
-    percent         = 0
-    latest_revision = true
+    percent = 0
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
   }
 }
 # [END cloudrun_service_traffic_gradual_rollout]

--- a/run/traffic_latest_revision/main.tf
+++ b/run/traffic_latest_revision/main.tf
@@ -16,15 +16,15 @@
 
 # [START cloudrun_traffic_latest_revision_parent_tag]
 # [START cloudrun_service_traffic_latest]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-srv"
   location = "us-central1"
 
   template {}
 
   traffic {
-    percent         = 100
-    latest_revision = true
+    percent = 100
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
   }
 }
 # [END cloudrun_service_traffic_latest]

--- a/run/traffic_rollback/main.tf
+++ b/run/traffic_rollback/main.tf
@@ -15,7 +15,7 @@
  */
 
 # [START cloudrun_service_traffic_rollback]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-srv"
   location = "us-central1"
 
@@ -24,7 +24,9 @@ resource "google_cloud_run_service" "default" {
   traffic {
     percent = 100
     # This revision needs to already exist
-    revision_name = "cloudrun-srv-green"
+    revision = "cloudrun-srv-green"
+    type     = "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"
+
   }
 }
 # [END cloudrun_service_traffic_rollback]

--- a/run/traffic_split/main.tf
+++ b/run/traffic_split/main.tf
@@ -15,30 +15,28 @@
  */
 
 # [START cloudrun_service_traffic_split]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-srv"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
-      }
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
     }
-    metadata {
-      name = "cloudrun-srv-green"
-    }
+    revision = "cloudrun-srv-green"
   }
 
   traffic {
-    percent       = 25
-    revision_name = "cloudrun-srv-green"
+    percent  = 25
+    revision = "cloudrun-srv-green"
+    type     = "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"
   }
 
   traffic {
     percent = 75
     # This revision needs to already exist
-    revision_name = "cloudrun-srv-blue"
+    revision = "cloudrun-srv-blue"
+    type     = "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"
   }
 }
 # [END cloudrun_service_traffic_split]

--- a/run/traffic_split/main.tf
+++ b/run/traffic_split/main.tf
@@ -26,6 +26,8 @@ resource "google_cloud_run_v2_service" "default" {
     revision = "cloudrun-srv-green"
   }
 
+  # Define the traffic split for each revision
+  # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#traffic
   traffic {
     percent  = 25
     revision = "cloudrun-srv-green"

--- a/run/traffic_split_tag/main.tf
+++ b/run/traffic_split_tag/main.tf
@@ -15,7 +15,7 @@
  */
 
 # [START cloudrun_service_traffic_split_tag]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-srv"
   location = "us-central1"
 
@@ -25,7 +25,8 @@ resource "google_cloud_run_service" "default" {
     # Update revision to 50% traffic
     percent = 50
     # This revision needs to already exist
-    revision_name = "cloudrun-srv-green"
+    revision = "cloudrun-srv-green"
+    type     = "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"
   }
 
   traffic {

--- a/run/traffic_split_tag/main.tf
+++ b/run/traffic_split_tag/main.tf
@@ -21,6 +21,8 @@ resource "google_cloud_run_v2_service" "default" {
 
   template {}
 
+  # Define the traffic split for each revision
+  # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#traffic
   traffic {
     # Update revision to 50% traffic
     percent = 50


### PR DESCRIPTION
## Description

Updates most Cloud Run samples to use google_cloud_run_v2_services.

go/tf-cloudrun_v2-update-plan

(after this PR, some references remain, to be handled separately)

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): many

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
