### PR TITLE
feat(compute): Add example to create a shared reservation

### DIFF
--- a/compute/reservation/create_specific_projects/main.tf
+++ b/compute/reservation/create_specific_projects/main.tf
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# [START compute_reservation_create_specific_projects_reservation]
+
+resource "google_compute_reservation" "default" {
+  name = "gce-reservation-specific-projects"
+  zone = "us-central1-a"
+
+  share_settings {
+    share_type = "SPECIFIC_PROJECTS"
+
+    project_map {
+      {
+        id = "project-1"
+      }
+      {
+        id = "project-2"
+      }
+    }
+  }
+
+  specific_reservation {
+    count = 1
+    instance_properties {
+      machine_type = "n2-standard-2"
+    }
+  }
+
+  /**
+   * To let VMs with affinity for any reservation consume this reservation, omit
+   * the specific_reservation_required field (default) or set it to false.
+   */
+  specific_reservation_required = false
+}
+
+# [END compute_reservation_create_specific_projects_reservation]


### PR DESCRIPTION
Specify how to create a single-project reservation by specifying properties directly.

## Description

Fixes #<ISSUE-NUMBER>

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [ ] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [ ] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [ ] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [ ] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [ ] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [ ] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
