### PR TITLE
fix: migrate run/container_template cloud run resource definition from v1 to v2

### DIFF
--- a/run/container_template/main.tf
+++ b/run/container_template/main.tf
@@ -17,111 +17,94 @@
 # Example configuration of a Cloud Run service
 
 # [START cloudrun_service_configuration]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "config"
   location = "us-central1"
 
   # [START cloudrun_service_configuration_containers]
   template {
-    spec {
-      containers {
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
 
-        # Container "entry-point" command
-        command = ["/server"]
+      # Container "entry-point" command
+      command = ["/server"]
 
-        # Container "entry-point" args
-        args = []
-        # [END cloudrun_service_configuration_containers]
-
-        # [START cloudrun_service_configuration_http2]
-        # Enable HTTP/2
-        ports {
-          name           = "h2c"
-          container_port = 8080
-        }
-        # [END cloudrun_service_configuration_http2]
-
-        # [START cloudrun_service_configuration_env_var]
-        # Environment variables
-        env {
-          name  = "foo"
-          value = "bar"
-        }
-        env {
-          name  = "baz"
-          value = "quux"
-        }
-        # [END cloudrun_service_configuration_env_var]
-
-        # [START cloudrun_service_configuration_limit_memory]
-        # [START cloudrun_service_configuration_limit_cpu]
-        resources {
-          limits = {
-            # CPU usage limit
-            cpu = "1000m" # 1 vCPU
-
-            # Memory usage limit (per container)
-            memory = "512Mi"
-          }
-        }
-        # [END cloudrun_service_configuration_limit_memory]
-        # [END cloudrun_service_configuration_limit_cpu]
-
-        # [START cloudrun_service_configuration_containers]
-      }
+      # Container "entry-point" args
+      args = []
       # [END cloudrun_service_configuration_containers]
 
-      # [START cloudrun_service_configuration_timeout]
-      # Timeout
-      timeout_seconds = 300
-      # [END cloudrun_service_configuration_timeout]
+      # [START cloudrun_service_configuration_http2]
+      # Enable HTTP/2
+      ports {
+        name           = "h2c"
+        container_port = 8080
+      }
+      # [END cloudrun_service_configuration_http2]
 
-      # [START cloudrun_service_configuration_concurrency]
-      # Maximum concurrent requests
-      container_concurrency = 80
-      # [END cloudrun_service_configuration_concurrency]
+      # [START cloudrun_service_configuration_env_var]
+      # Environment variables
+      env {
+        name  = "foo"
+        value = "bar"
+      }
+      env {
+        name  = "baz"
+        value = "quux"
+      }
+      # [END cloudrun_service_configuration_env_var]
+
+      # [START cloudrun_service_configuration_limit_memory]
+      # [START cloudrun_service_configuration_limit_cpu]
+      resources {
+        limits = {
+          # CPU usage limit
+          cpu = "1" # 1 vCPU
+
+          # Memory usage limit (per container)
+          memory = "512Mi"
+        }
+        # If true, garbage-collect CPU when once a request finishes
+        cpu_idle = false
+      }
+      # [END cloudrun_service_configuration_limit_memory]
+      # [END cloudrun_service_configuration_limit_cpu]
 
       # [START cloudrun_service_configuration_containers]
     }
     # [END cloudrun_service_configuration_containers]
 
+    # [START cloudrun_service_configuration_timeout]
+    # Timeout
+    timeout = "300s"
+    # [END cloudrun_service_configuration_timeout]
+
+    # [START cloudrun_service_configuration_concurrency]
+    # Maximum concurrent requests
+    max_instance_request_concurrency = 80
+    # [END cloudrun_service_configuration_concurrency]
+
     # [START cloudrun_service_configuration_max_instances]
     # [START cloudrun_service_configuration_min_instances]
-    # [START cloudrun_service_configuration_labels]
-    metadata {
-      # [END cloudrun_service_configuration_labels]
-      annotations = {
+    scaling {
+      # Max instances
+      max_instance_count = 10
 
-        # Max instances
-        "autoscaling.knative.dev/maxScale" = 10
-
-        # Min instances
-        "autoscaling.knative.dev/minScale" = 1
-
-        # If true, garbage-collect CPU when once a request finishes
-        "run.googleapis.com/cpu-throttling" = false
-      }
-      # [END cloudrun_service_configuration_max_instances]
-      # [END cloudrun_service_configuration_min_instances]
-
-      # [START cloudrun_service_configuration_labels]
-      # Labels
-      labels = {
-        foo : "bar"
-        baz : "quux"
-      }
-      # [START cloudrun_service_configuration_max_instances]
-      # [START cloudrun_service_configuration_min_instances]
+      # Min instances
+      min_instance_count = 1
     }
-    # [END cloudrun_service_configuration_labels]
     # [END cloudrun_service_configuration_max_instances]
     # [END cloudrun_service_configuration_min_instances]
   }
 
-  traffic {
-    percent         = 100
-    latest_revision = true
+  # [START cloudrun_service_configuration_labels]
+  # Labels
+  labels = {
+    foo : "bar"
+    baz : "quux"
   }
+  # [END cloudrun_service_configuration_labels]
+  
+  # [START cloudrun_service_configuration_containers]
 }
+# [END cloudrun_service_configuration_containers]
 # [END cloudrun_service_configuration]

--- a/run/container_template/main.tf
+++ b/run/container_template/main.tf
@@ -28,17 +28,14 @@ resource "google_cloud_run_service" "default" {
         image = "us-docker.pkg.dev/cloudrun/container/hello"
 
         # Container "entry-point" command
-        # https://cloud.google.com/run/docs/configuring/containers#configure-entrypoint
         command = ["/server"]
 
         # Container "entry-point" args
-        # https://cloud.google.com/run/docs/configuring/containers#configure-entrypoint
         args = []
         # [END cloudrun_service_configuration_containers]
 
         # [START cloudrun_service_configuration_http2]
         # Enable HTTP/2
-        # https://cloud.google.com/run/docs/configuring/http2
         ports {
           name           = "h2c"
           container_port = 8080
@@ -47,7 +44,6 @@ resource "google_cloud_run_service" "default" {
 
         # [START cloudrun_service_configuration_env_var]
         # Environment variables
-        # https://cloud.google.com/run/docs/configuring/environment-variables
         env {
           name  = "foo"
           value = "bar"
@@ -63,11 +59,9 @@ resource "google_cloud_run_service" "default" {
         resources {
           limits = {
             # CPU usage limit
-            # https://cloud.google.com/run/docs/configuring/cpu
             cpu = "1000m" # 1 vCPU
 
             # Memory usage limit (per container)
-            # https://cloud.google.com/run/docs/configuring/memory-limits
             memory = "512Mi"
           }
         }
@@ -80,13 +74,11 @@ resource "google_cloud_run_service" "default" {
 
       # [START cloudrun_service_configuration_timeout]
       # Timeout
-      # https://cloud.google.com/run/docs/configuring/request-timeout
       timeout_seconds = 300
       # [END cloudrun_service_configuration_timeout]
 
       # [START cloudrun_service_configuration_concurrency]
       # Maximum concurrent requests
-      # https://cloud.google.com/run/docs/configuring/concurrency
       container_concurrency = 80
       # [END cloudrun_service_configuration_concurrency]
 
@@ -102,15 +94,12 @@ resource "google_cloud_run_service" "default" {
       annotations = {
 
         # Max instances
-        # https://cloud.google.com/run/docs/configuring/max-instances
         "autoscaling.knative.dev/maxScale" = 10
 
         # Min instances
-        # https://cloud.google.com/run/docs/configuring/min-instances
         "autoscaling.knative.dev/minScale" = 1
 
         # If true, garbage-collect CPU when once a request finishes
-        # https://cloud.google.com/run/docs/configuring/cpu-allocation
         "run.googleapis.com/cpu-throttling" = false
       }
       # [END cloudrun_service_configuration_max_instances]
@@ -118,7 +107,6 @@ resource "google_cloud_run_service" "default" {
 
       # [START cloudrun_service_configuration_labels]
       # Labels
-      # https://cloud.google.com/run/docs/configuring/labels
       labels = {
         foo : "bar"
         baz : "quux"

--- a/run/container_template/main.tf
+++ b/run/container_template/main.tf
@@ -55,7 +55,9 @@ resource "google_cloud_run_v2_service" "default" {
 
       # [START cloudrun_service_configuration_limit_memory]
       # [START cloudrun_service_configuration_limit_cpu]
+      # [START cloudrun_service_configuration_cpu_allocation]
       resources {
+        # [END cloudrun_service_configuration_cpu_allocation]
         limits = {
           # CPU usage limit
           cpu = "1" # 1 vCPU
@@ -63,9 +65,11 @@ resource "google_cloud_run_v2_service" "default" {
           # Memory usage limit (per container)
           memory = "512Mi"
         }
+        # [START cloudrun_service_configuration_cpu_allocation]
         # If true, garbage-collect CPU when once a request finishes
         cpu_idle = false
       }
+      # [START cloudrun_service_configuration_cpu_allocation]
       # [END cloudrun_service_configuration_limit_memory]
       # [END cloudrun_service_configuration_limit_cpu]
 
@@ -103,7 +107,7 @@ resource "google_cloud_run_v2_service" "default" {
     baz : "quux"
   }
   # [END cloudrun_service_configuration_labels]
-  
+
   # [START cloudrun_service_configuration_containers]
 }
 # [END cloudrun_service_configuration_containers]


### PR DESCRIPTION
## Description

* Migrates /run/container_template from https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service to https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service
* Introduces new tag cloudrun_service_configuration_cpu_allocation
* (should) update start/end region tag boundaries to reflect nesting changes, attribute changes.
* remove inline docs references (when viewed as a snippet, this links to the same page the user is currently on. when viewed as a sample, the page already has a link to this page in 'explore further')

_do not merge until_: associated CL is ready (cl/551399196)

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [ ] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [ ] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):
* New region tag cloudrun_service_configuration_cpu_allocation for https://cloud.google.com/run/docs/configuring/cpu-allocation

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
