### PR TITLE
chore(run): Remove variables from `multiple_regions` sample (2 of 2)

### DIFF
--- a/run/multiple_regions/main.tf
+++ b/run/multiple_regions/main.tf
@@ -16,6 +16,12 @@
 
 # Cloud Run service replicated across multiple GCP regions
 
+# [START cloudrun_multiregion_variables]
+locals {
+  run_regions = ["us-central1", "europe-west1"]
+}
+# [END cloudrun_multiregion_variables]
+
 # [START cloudrun_multiple_regions_parent_tag]
 resource "google_project_service" "compute_api" {
   provider                   = google-beta
@@ -30,13 +36,6 @@ resource "google_project_service" "run_api" {
   disable_dependent_services = false
   disable_on_destroy         = false
 }
-
-# [START cloudrun_multiregion_variables]
-variable "run_regions" {
-  type    = list(string)
-  default = ["us-central1", "europe-west1"]
-}
-# [END cloudrun_multiregion_variables]
 
 # [START cloudrun_multiregion_addr]
 resource "google_compute_global_address" "lb_default" {
@@ -130,10 +129,10 @@ resource "google_compute_global_forwarding_rule" "lb_default" {
 # [START cloudrun_multiregion_neg]
 resource "google_compute_region_network_endpoint_group" "lb_default" {
   provider              = google-beta
-  count                 = length(var.run_regions)
+  count                 = length(local.run_regions)
   name                  = "myservice-neg"
   network_endpoint_type = "SERVERLESS"
-  region                = var.run_regions[count.index]
+  region                = local.run_regions[count.index]
   cloud_run {
     service = google_cloud_run_v2_service.run_default[count.index].name
   }
@@ -149,9 +148,9 @@ output "load_balancer_ip_addr" {
 # [START cloudrun_multiregion_service]
 resource "google_cloud_run_v2_service" "run_default" {
   provider = google-beta
-  count    = length(var.run_regions)
-  name     = "myservice-run-app-${var.run_regions[count.index]}"
-  location = var.run_regions[count.index]
+  count    = length(local.run_regions)
+  name     = "myservice-run-app-${local.run_regions[count.index]}"
+  location = local.run_regions[count.index]
 
   template {
     containers {
@@ -169,7 +168,7 @@ resource "google_cloud_run_v2_service" "run_default" {
 # [START cloudrun_multiregion_service_iam]
 resource "google_cloud_run_service_iam_member" "run_allow_unauthenticated" {
   provider = google-beta
-  count    = length(var.run_regions)
+  count    = length(local.run_regions)
   location = google_cloud_run_v2_service.run_default[count.index].location
   service  = google_cloud_run_v2_service.run_default[count.index].name
   role     = "roles/run.invoker"

--- a/run/multiple_regions/main.tf
+++ b/run/multiple_regions/main.tf
@@ -32,11 +32,6 @@ resource "google_project_service" "run_api" {
 }
 
 # [START cloudrun_multiregion_variables]
-variable "domain_name" {
-  type    = string
-  default = "example.com"
-}
-
 variable "run_regions" {
   type    = list(string)
   default = ["us-central1", "europe-west1"]
@@ -106,14 +101,6 @@ resource "google_compute_managed_ssl_certificate" "lb_default" {
   }
 }
 # [END cloudrun_multiregion_cert]
-
-# Defined following to avoid unused variable lint error for `domain_name` variable
-resource "local_file" "example" {
-  content  = "${var.domain_name}\n"
-  filename = "/tmp/example_text_file.txt"
-}
-
-
 # [START cloudrun_multiregion_proxy_https]
 resource "google_compute_target_https_proxy" "lb_default" {
   provider = google-beta


### PR DESCRIPTION
This PR removes the use of variables from the multiple_regions run sample  per our [published style guide](https://googlecloudplatform.github.io/samples-style-guide/#no-global-variables).
- It replaces the `run_regions` variable with a local value
- removes the `domain_name` variable as it is no longer referenced in [the documentation](https://cloud.google.com/run/docs/multiple-regions#:~:text=Replace%20example.com%20with%20your%20domain%20name%3A)

This PR is a followup to #468 