### PR TITLE
add: `bigquery_create_object_table`

### DIFF
--- a/bigquery/bigquery_create_object_table/main.tf
+++ b/bigquery/bigquery_create_object_table/main.tf
@@ -16,11 +16,6 @@
 */
 
 # [START bigquery_create_object_table]
-provider "google" {
-  project = "bq-huron"
-  region  = "us-central1"
-}
-
 resource "google_bigquery_connection" "default" {
   connection_id = "my-connection-id"
   location      = "US"
@@ -31,7 +26,7 @@ data "google_project" "project" {}
 
 resource "google_project_iam_member" "default" {
   role    = "roles/storage.objectViewer"
-  project = data.google_project.project.id
+  project = data.google_project.project.project_id
   member  = "serviceAccount:${google_bigquery_connection.default.cloud_resource[0].service_account_id}"
 }
 

--- a/bigquery/bigquery_create_object_table/main.tf
+++ b/bigquery/bigquery_create_object_table/main.tf
@@ -16,8 +16,8 @@
 /*
 * This sample demonstrates how to create an Object Table in BigQuery.
 * For more information please refer to:
-* http://cloud/bigquery/docs/object-table-introduction
-* http://cloud/bigquery/docs/object-tables
+* https://cloud.google.com/bigquery/docs/object-table-introduction
+* https://cloud.google.com/bigquery/docs/object-tables
 */
 
 # [START bigquery_create_object_table]

--- a/bigquery/bigquery_create_object_table/main.tf
+++ b/bigquery/bigquery_create_object_table/main.tf
@@ -1,4 +1,3 @@
-
 /**
 * Copyright 2023 Google LLC
 *
@@ -60,13 +59,13 @@ resource "google_bigquery_table" "default" {
     metadata_cache_mode = "MANUAL"
   }
 
-  # `max_staleness` must be specified as an interval literal, 
+  # `max_staleness` must be specified as an interval literal,
   # when `metadata_cache_mode` is `AUTOMATIC`, omitted otherwise.
   # Interval literal: https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#interval_literals
   # max_staleness = "0-0 0 10:0:0"
 
   # Ensure the connection can access the bucket before table creation.
-  # Without this dependency, Terraform may try to create the table when 
+  # Without this dependency, Terraform may try to create the table when
   # the connection does not have the correct IAM Role resulting in failures.
   depends_on = [
     google_project_iam_member.default

--- a/bigquery/bigquery_create_object_table/main.tf
+++ b/bigquery/bigquery_create_object_table/main.tf
@@ -1,0 +1,82 @@
+
+/**
+* Copyright 2023 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+# [START bigquery_create_object_table]
+provider "google" {
+  project = "bq-huron"
+  region  = "us-central1"
+}
+
+resource "google_bigquery_connection" "test" {
+  connection_id = "my-connection-id"
+  location      = "US"
+  cloud_resource {}
+}
+
+data "google_project" "project" {}
+
+resource "google_project_iam_member" "test" {
+  role    = "roles/storage.objectViewer"
+  project = data.google_project.project.id
+  member  = "serviceAccount:${google_bigquery_connection.test.cloud_resource[0].service_account_id}"
+}
+
+resource "google_bigquery_dataset" "test" {
+  dataset_id = "my_dataset_id"
+}
+
+resource "google_storage_bucket" "test" {
+  name                        = "my-bucket-81123"
+  location                    = "US"
+  force_destroy               = true
+  uniform_bucket_level_access = true
+}
+
+resource "google_bigquery_table" "test" {
+  deletion_protection = false
+  table_id            = "my-table-id"
+  dataset_id          = google_bigquery_dataset.test.dataset_id
+  external_data_configuration {
+    connection_id = google_bigquery_connection.test.name
+    autodetect    = false
+    # REQUIRED for object tables.
+    object_metadata = "SIMPLE"
+
+    source_uris = [
+      "gs://${google_storage_bucket.test.name}/*",
+    ]
+
+    # `MANUAL` for manual metadata refresh
+    # `AUTOMATIC` for automatic metadata refresh.
+    metadata_cache_mode = "MANUAL"
+  }
+
+  # `max_staleness` must be specified when `metadata_cache_mode`
+  # is `AUTOMATIC`. And omitted when `MANUAL`.
+  # encoded as a string encoding of sql IntervalValue type
+  # (canonical format).
+  # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#interval_type
+  # max_staleness = "0-0 0 10:0:0"
+
+  # Ensure the connection can access the bucket before table creation.
+  # Without this dependency, Terraform may try to create the table when 
+  # the connection does not have the correct IAM Role resulting in failures.
+  depends_on = [
+    google_project_iam_member.test
+  ]
+}
+# [END bigquery_create_object_table]

--- a/bigquery/bigquery_create_object_table/main.tf
+++ b/bigquery/bigquery_create_object_table/main.tf
@@ -21,7 +21,7 @@ provider "google" {
   region  = "us-central1"
 }
 
-resource "google_bigquery_connection" "test" {
+resource "google_bigquery_connection" "default" {
   connection_id = "my-connection-id"
   location      = "US"
   cloud_resource {}
@@ -29,35 +29,35 @@ resource "google_bigquery_connection" "test" {
 
 data "google_project" "project" {}
 
-resource "google_project_iam_member" "test" {
+resource "google_project_iam_member" "default" {
   role    = "roles/storage.objectViewer"
   project = data.google_project.project.id
-  member  = "serviceAccount:${google_bigquery_connection.test.cloud_resource[0].service_account_id}"
+  member  = "serviceAccount:${google_bigquery_connection.default.cloud_resource[0].service_account_id}"
 }
 
-resource "google_bigquery_dataset" "test" {
+resource "google_bigquery_dataset" "default" {
   dataset_id = "my_dataset_id"
 }
 
-resource "google_storage_bucket" "test" {
+resource "google_storage_bucket" "default" {
   name                        = "my-bucket-81123"
   location                    = "US"
   force_destroy               = true
   uniform_bucket_level_access = true
 }
 
-resource "google_bigquery_table" "test" {
+resource "google_bigquery_table" "default" {
   deletion_protection = false
   table_id            = "my-table-id"
-  dataset_id          = google_bigquery_dataset.test.dataset_id
+  dataset_id          = google_bigquery_dataset.default.dataset_id
   external_data_configuration {
-    connection_id = google_bigquery_connection.test.name
+    connection_id = google_bigquery_connection.default.name
     autodetect    = false
     # REQUIRED for object tables.
     object_metadata = "SIMPLE"
 
     source_uris = [
-      "gs://${google_storage_bucket.test.name}/*",
+      "gs://${google_storage_bucket.default.name}/*",
     ]
 
     # `MANUAL` for manual metadata refresh
@@ -74,7 +74,7 @@ resource "google_bigquery_table" "test" {
   # Without this dependency, Terraform may try to create the table when 
   # the connection does not have the correct IAM Role resulting in failures.
   depends_on = [
-    google_project_iam_member.test
+    google_project_iam_member.default
   ]
 }
 # [END bigquery_create_object_table]

--- a/bigquery/bigquery_create_object_table/main.tf
+++ b/bigquery/bigquery_create_object_table/main.tf
@@ -33,8 +33,12 @@ resource "google_bigquery_dataset" "default" {
   dataset_id = "my_dataset_id"
 }
 
+# Cloud Storage bucket name must be unique
+resource "random_id" "bucket_name_suffix" {
+  byte_length = 8
+}
 resource "google_storage_bucket" "default" {
-  name                        = "my-bucket-81123"
+  name                        = "my-bucket-${random_id.bucket_name_suffix.hex}"
   location                    = "US"
   force_destroy               = true
   uniform_bucket_level_access = true

--- a/bigquery/bigquery_create_object_table/main.tf
+++ b/bigquery/bigquery_create_object_table/main.tf
@@ -13,6 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+/*
+* This sample demonstrates how to create an Object Table in BigQuery.
+* For more information please refer to:
+* http://cloud/bigquery/docs/object-table-introduction
+* http://cloud/bigquery/docs/object-tables
+*/
 
 # [START bigquery_create_object_table]
 resource "google_bigquery_connection" "default" {

--- a/bigquery/bigquery_create_object_table/main.tf
+++ b/bigquery/bigquery_create_object_table/main.tf
@@ -65,11 +65,9 @@ resource "google_bigquery_table" "test" {
     metadata_cache_mode = "MANUAL"
   }
 
-  # `max_staleness` must be specified when `metadata_cache_mode`
-  # is `AUTOMATIC`. And omitted when `MANUAL`.
-  # encoded as a string encoding of sql IntervalValue type
-  # (canonical format).
-  # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#interval_type
+  # `max_staleness` must be specified as an interval literal, 
+  # when `metadata_cache_mode` is `AUTOMATIC`, omitted otherwise.
+  # Interval literal: https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#interval_literals
   # max_staleness = "0-0 0 10:0:0"
 
   # Ensure the connection can access the bucket before table creation.

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -40,6 +40,7 @@ module "projects" {
     "aiplatform.googleapis.com",
     "artifactregistry.googleapis.com",
     "bigquery.googleapis.com",
+    "bigqueryconnection.googleapis.com",
     "certificatemanager.googleapis.com",
     "compute.googleapis.com",
     "cloudbuild.googleapis.com",


### PR DESCRIPTION
## Description

Intending to use this snippet on the following page:
https://cloud.google.com/bigquery/docs/object-tables

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):
https://cloud.google.com/bigquery/docs/object-tables#create-object-table

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [x] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
