### PR TITLE
fix: update Cloud Run configurations to v2 resource

### DIFF
--- a/run/cloud_run_configuration_concurrency/main.tf
+++ b/run/cloud_run_configuration_concurrency/main.tf
@@ -17,19 +17,16 @@
 # Example configuration of a Cloud Run service with concurrency set
 
 # [START cloudrun_service_configuration_concurrency]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-service-concurrency"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
-      }
-      # Maximum concurrent requests
-      # https://cloud.google.com/run/docs/configuring/concurrency
-      container_concurrency = 80
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
     }
+    # Maximum concurrent requests
+    max_instance_request_concurrency = 80
   }
 }
 # [END cloudrun_service_configuration_concurrency]

--- a/run/cloud_run_configuration_containers/main.tf
+++ b/run/cloud_run_configuration_containers/main.tf
@@ -17,23 +17,19 @@
 # Example configuration of a Cloud Run service with command and args
 
 # [START cloudrun_service_configuration_containers]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-service-containers"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
 
-        # Container "entry-point" command
-        # https://cloud.google.com/run/docs/configuring/containers#configure-entrypoint
-        command = ["/server"]
+      # Container "entry-point" command
+      command = ["/server"]
 
-        # Container "entry-point" args
-        # https://cloud.google.com/run/docs/configuring/containers#configure-entrypoint
-        args = []
-      }
+      # Container "entry-point" args
+      args = []
     }
   }
 }

--- a/run/cloud_run_configuration_cpu/main.tf
+++ b/run/cloud_run_configuration_cpu/main.tf
@@ -17,28 +17,28 @@
 # Example configuration of a Cloud Run service with CPU limit
 
 # [START cloudrun_service_configuration_cpu]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-service-cpu"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
-        resources {
-          limits = {
-            # CPU usage limit
-            # https://cloud.google.com/run/docs/configuring/cpu
-            cpu = "1000m" # 1 vCPU
-          }
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+      resources {
+        limits = {
+          # CPU usage limit
+          cpu = "1"
         }
       }
     }
   }
+  # [END cloudrun_service_configuration_cpu]
   lifecycle {
     ignore_changes = [
-      template[0].spec[0].containers[0].resources[0].limits,
+      template[0].containers[0].resources[0].limits,
     ]
   }
+  # [START cloudrun_service_configuration_cpu]
 }
+
 # [END cloudrun_service_configuration_cpu]

--- a/run/cloud_run_configuration_environment_variables/main.tf
+++ b/run/cloud_run_configuration_environment_variables/main.tf
@@ -17,25 +17,22 @@
 # Example configuration of a Cloud Run service with environment variables
 
 # [START cloudrun_service_configuration_env_var]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-service-env-var"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
 
-        # Environment variables
-        # https://cloud.google.com/run/docs/configuring/environment-variables
-        env {
-          name  = "foo"
-          value = "bar"
-        }
-        env {
-          name  = "baz"
-          value = "quux"
-        }
+      # Environment variables
+      env {
+        name  = "foo"
+        value = "bar"
+      }
+      env {
+        name  = "baz"
+        value = "quux"
       }
     }
   }

--- a/run/cloud_run_configuration_http2/main.tf
+++ b/run/cloud_run_configuration_http2/main.tf
@@ -17,20 +17,17 @@
 # Example configuration of a Cloud Run service with h2c enabled
 
 # [START cloudrun_service_configuration_h2c]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-service-h2c"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
-        # Enable HTTP/2
-        # https://cloud.google.com/run/docs/configuring/http2
-        ports {
-          name           = "h2c"
-          container_port = 8080
-        }
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+      # Enable HTTP/2
+      ports {
+        name           = "h2c"
+        container_port = 8080
       }
     }
   }

--- a/run/cloud_run_configuration_labels/main.tf
+++ b/run/cloud_run_configuration_labels/main.tf
@@ -17,23 +17,18 @@
 # Example configuration of a Cloud Run service with labels
 
 # [START cloudrun_service_configuration_labels]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-service-labels"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
-      }
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
     }
-    metadata {
-      # Labels
-      # https://cloud.google.com/run/docs/configuring/labels
-      labels = {
-        foo : "bar"
-        baz : "quux"
-      }
+    # Labels
+    labels = {
+      foo : "bar"
+      baz : "quux"
     }
   }
 }

--- a/run/cloud_run_configuration_max_instances/main.tf
+++ b/run/cloud_run_configuration_max_instances/main.tf
@@ -17,28 +17,25 @@
 # Example configuration of a Cloud Run service with max instances
 
 # [START cloudrun_service_configuration_max_instances]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-service-max-instances"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
-      }
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
     }
-    metadata {
-      annotations = {
-        # Max instances
-        # https://cloud.google.com/run/docs/configuring/max-instances
-        "autoscaling.knative.dev/maxScale" = 10
-      }
+    scaling {
+      # Max instances
+      max_instance_count = 10
     }
   }
+  # [END cloudrun_service_configuration_max_instances]
   lifecycle {
     ignore_changes = [
-      template[0].metadata[0].annotations,
+      template[0].scaling,
     ]
   }
+  # [START cloudrun_service_configuration_max_instances]
 }
 # [END cloudrun_service_configuration_max_instances]

--- a/run/cloud_run_configuration_memory_limits/main.tf
+++ b/run/cloud_run_configuration_memory_limits/main.tf
@@ -17,29 +17,28 @@
 # Example configuration of a Cloud Run service with memory limit
 
 # [START cloudrun_service_configuration_memory_limits]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-service-memory-limits"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
 
-        resources {
-          limits = {
-            # Memory usage limit (per container)
-            # https://cloud.google.com/run/docs/configuring/memory-limits
-            memory = "512Mi"
-          }
+      resources {
+        limits = {
+          # Memory usage limit (per container)
+          memory = "512Mi"
         }
       }
     }
   }
+  # [END cloudrun_service_configuration_memory_limits]
   lifecycle {
     ignore_changes = [
-      template[0].spec[0].containers[0].resources[0].limits,
+      template[0].containers[0].resources[0].limits,
     ]
   }
+  # [START cloudrun_service_configuration_memory_limits]
 }
 # [END cloudrun_service_configuration_memory_limits]

--- a/run/cloud_run_configuration_min_instances/main.tf
+++ b/run/cloud_run_configuration_min_instances/main.tf
@@ -17,28 +17,29 @@
 # Example configuration of a Cloud Run service with min instances
 
 # [START cloudrun_service_configuration_min_instances]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-service-min-instances"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
-      }
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
     }
-    metadata {
-      annotations = {
-        # Min instances
-        # https://cloud.google.com/run/docs/configuring/min-instances
-        "autoscaling.knative.dev/minScale" = 1
-      }
+    scaling {
+      # Min instances
+      min_instance_count = 1
+      # [END cloudrun_service_configuration_min_instances]
+      # Add to prevent violation: "max_instance_count: must be greater or equal than min_instance_count.""
+      max_instance_count = 2
+      # [START cloudrun_service_configuration_min_instances]
     }
   }
+  # [END cloudrun_service_configuration_min_instances]
   lifecycle {
     ignore_changes = [
-      template[0].metadata[0].annotations,
+      template[0].scaling,
     ]
   }
+  # [START cloudrun_service_configuration_min_instances]
 }
 # [END cloudrun_service_configuration_min_instances]

--- a/run/cloud_run_configuration_request_timeout/main.tf
+++ b/run/cloud_run_configuration_request_timeout/main.tf
@@ -17,19 +17,16 @@
 # Example configuration of a Cloud Run service with request timeout
 
 # [START cloudrun_service_configuration_request_timeout]
-resource "google_cloud_run_service" "default" {
+resource "google_cloud_run_v2_service" "default" {
   name     = "cloudrun-service-request-timeout"
   location = "us-central1"
 
   template {
-    spec {
-      containers {
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
-      }
-      # Timeout
-      # https://cloud.google.com/run/docs/configuring/request-timeout
-      timeout_seconds = 300
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
     }
+    # Timeout
+    timeout = "300s"
   }
 }
 # [END cloudrun_service_configuration_request_timeout]

--- a/run/healthchecks_liveness_probe_grpc/main.tf
+++ b/run/healthchecks_liveness_probe_grpc/main.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-provider "google-beta" {
-  region = "us-central1"
-}
-
 # Enable Cloud Run API
 resource "google_project_service" "cloudrun_api" {
   service            = "run.googleapis.com"
@@ -27,7 +23,6 @@ resource "google_project_service" "cloudrun_api" {
 # Create Cloud Run Container with gRPC liveness probe
 #[START cloud_run_healthchecks_liveness_probe_gRPC]
 resource "google_cloud_run_v2_service" "default" {
-  provider = google-beta
   name     = "cloudrun-service-healthcheck"
   location = "us-central1"
 

--- a/run/healthchecks_liveness_probe_http/main.tf
+++ b/run/healthchecks_liveness_probe_http/main.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-provider "google-beta" {
-  region = "us-central1"
-}
-
 # Enable Cloud Run API
 resource "google_project_service" "cloudrun_api" {
   service            = "run.googleapis.com"
@@ -27,7 +23,6 @@ resource "google_project_service" "cloudrun_api" {
 # Create Cloud Run Container with HTTP liveness probe
 #[START cloud_run_healthchecks_liveness_probe_http]
 resource "google_cloud_run_v2_service" "default" {
-  provider = google-beta
   name     = "cloudrun-service-healthcheck"
   location = "us-central1"
 

--- a/run/healthchecks_startup_probe_http/main.tf
+++ b/run/healthchecks_startup_probe_http/main.tf
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-provider "google-beta" {
-  region = "us-central1"
-}
 
 # Enable Cloud Run API
 resource "google_project_service" "cloudrun_api" {
@@ -27,7 +24,6 @@ resource "google_project_service" "cloudrun_api" {
 # Create Cloud Run Container with HTTP startup probe
 #[START cloud_run_healthchecks_startup_probe_http]
 resource "google_cloud_run_v2_service" "default" {
-  provider = google-beta
   name     = "cloudrun-service-healthcheck"
   location = "us-central1"
 

--- a/run/healthchecks_startup_probe_tcp/main.tf
+++ b/run/healthchecks_startup_probe_tcp/main.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-provider "google-beta" {
-  region = "us-central1"
-}
-
 # Enable Cloud Run API
 resource "google_project_service" "cloudrun_api" {
   service            = "run.googleapis.com"
@@ -27,7 +23,6 @@ resource "google_project_service" "cloudrun_api" {
 # Create Cloud Run Container with TCP startup probe
 #[START cloud_run_healthchecks_startup_probe_tcp]
 resource "google_cloud_run_v2_service" "default" {
-  provider = google-beta
   name     = "cloudrun-service-healthcheck"
   location = "us-central1"
 


### PR DESCRIPTION
## Description

Assists b/290538179

Pairs with cl/557303797

Updates google_cloud_run_service to google_cloud_run_v2_service

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com



**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
