### PR TITLE
feat: add cpu allocation, description samples for Cloud Run

### DIFF
--- a/run/cloud_run_configuration_cpu_allocation/main.tf
+++ b/run/cloud_run_configuration_cpu_allocation/main.tf
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# Example configuration of a Cloud Run service with CPU limit
+
+# [START cloudrun_service_configuration_cpu_allocation]
+resource "google_cloud_run_v2_service" "default" {
+  name     = "cloudrun-service-cpu-allocation"
+  location = "us-central1"
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+      resources {
+        # If true, garbage-collect CPU when once a request finishes
+        cpu_idle = false
+      }
+    }
+  }
+}
+# [END cloudrun_service_configuration_cpu_allocation]

--- a/run/cloud_run_configuration_description/main.tf
+++ b/run/cloud_run_configuration_description/main.tf
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# Example configuration of a Cloud Run service with labels
+
+# [START cloudrun_service_configuration_description]
+resource "google_cloud_run_v2_service" "default" {
+  name     = "cloudrun-service-description"
+  location = "us-central1"
+
+  description = "This service has a custom description"
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+  }
+
+}
+# [END cloudrun_service_configuration_description]


### PR DESCRIPTION
## Description

Addresses b/290538179

Adds examples for Cloud Run description, cpu allocation

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Intended location**

- [ ] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):
   
* https://cloud.devsite.corp.google.com/run/docs/configuring/cpu-allocation
* https://cloud.devsite.corp.google.com/run/docs/configuring/description 

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
