### PR TITLE
feat(networkconnectivity): Add samples for creating a service-connection-policy

### DIFF
--- a/network_connectivity/service_connectivity_automation/service_connection_policies/main.tf
+++ b/network_connectivity/service_connectivity_automation/service_connection_policies/main.tf
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-# [START networkconnectivity_create_service_connection_policy]
+# [START networkconnectivitycenter_create_service_connection_policy]
 # Create a VPC network
 resource "google_compute_network" "default" {
   name                    = "consumer-network"
@@ -40,5 +40,5 @@ resource "google_network_connectivity_service_connection_policy" "default" {
     limit       = 2
   }
 }
-# [END networkconnectivity_create_service_connection_policy]
+# [END networkconnectivitycenter_create_service_connection_policy]
 

--- a/network_connectivity/service_connectivity_automation/service_connection_policies/main.tf
+++ b/network_connectivity/service_connectivity_automation/service_connection_policies/main.tf
@@ -33,7 +33,7 @@ resource "google_compute_subnetwork" "default" {
 resource "google_network_connectivity_service_connection_policy" "default" {
   name          = "my-service-connection-policy"
   location      = "us-central1"
-  service_class = "my-service-class" # Replace `my-service-class` with the name of a valid service class
+  service_class = "gcp-memorystore-redis"
   description   = "Description"
   network       = google_compute_network.default.id
   psc_config {

--- a/network_connectivity/service_connectivity_automation/service_connection_policies/main.tf
+++ b/network_connectivity/service_connectivity_automation/service_connection_policies/main.tf
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-# [START network_connectivity_create_service_connection_policy]
+# [START networkconnectivity_create_service_connection_policy]
 # Create a VPC network
 resource "google_compute_network" "default" {
   name                    = "consumer-network"
@@ -41,5 +41,5 @@ resource "google_network_connectivity_service_connection_policy" "default" {
     limit       = 2
   }
 }
-# [END network_connectivity_create_service_connection_policy]
+# [END networkconnectivity_create_service_connection_policy]
 

--- a/network_connectivity/service_connectivity_automation/service_connection_policies/main.tf
+++ b/network_connectivity/service_connectivity_automation/service_connection_policies/main.tf
@@ -31,10 +31,9 @@ resource "google_compute_subnetwork" "default" {
 
 # Create a service connection policy
 resource "google_network_connectivity_service_connection_policy" "default" {
-  name          = "my-service-connection-policy"
+  name          = "service-connection-policy"
   location      = "us-central1"
   service_class = "gcp-memorystore-redis"
-  description   = "Description"
   network       = google_compute_network.default.id
   psc_config {
     subnetworks = [google_compute_subnetwork.default.id]

--- a/network_connectivity/service_connectivity_automation/service_connection_policies/main.tf
+++ b/network_connectivity/service_connectivity_automation/service_connection_policies/main.tf
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# [START network_connectivity_create_service_connection_policy]
+# Create a VPC network
+resource "google_compute_network" "default" {
+  name                    = "consumer-network"
+  auto_create_subnetworks = false
+}
+
+# Create a subnetwork
+resource "google_compute_subnetwork" "default" {
+  name          = "consumer-subnet"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
+}
+
+# Create a service connection policy
+resource "google_network_connectivity_service_connection_policy" "default" {
+  name          = "my-service-connection-policy"
+  location      = "us-central1"
+  service_class = "my-service-class" # Replace `my-service-class` with the name of a valid service class
+  description   = "Description"
+  network       = google_compute_network.default.id
+  psc_config {
+    subnetworks = [google_compute_subnetwork.default.id]
+    limit       = 2
+  }
+}
+# [END network_connectivity_create_service_connection_policy]
+

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -53,6 +53,7 @@ module "projects" {
     "eventarc.googleapis.com",
     "iam.googleapis.com",
     "looker.googleapis.com",
+    "networkconnectivity.googleapis.com",
     "networkmanagement.googleapis.com",
     "notebooks.googleapis.com",
     "privateca.googleapis.com",


### PR DESCRIPTION
## Description

I'm creating this as a draft PR because I haven't been able to run the tests at https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment. I was able to try `terraform apply` and verify that it created the right resources in my test project. 

Fixes #302014019

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [X] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [X] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [X] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**
I have not been able to complete the tests below. After following the steps in the guide, `make -s docker_test_sample SAMPLE=networkconnectivity_create_service_connection_policy` ends with
```
TestSamples 2023-09-26T18:48:32Z command.go:185: ["ci-tf-samples-0-531d","ci-tf-samples-1-9fe6","ci-tf-samples-2-fda6","ci-tf-samples-3-8a5b"]
--- PASS: TestSamples (1.74s)
testing: warning: no tests to run
PASS
ok      github.com/terraform-google-modules/terraform-docs-samples/test/integration     1.759s
```
- [ ] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [X] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [X] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): https://cloud.google.com/vpc/docs/configure-service-connection-policies#create-policy

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [X] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

Added sample under the existing network_connectivity directory.

- [X] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)