### PR TITLE
fix(run): replace `automatic` with `auto` param in secrets resources

### DIFF
--- a/run/connect_cloud_sql/main.tf
+++ b/run/connect_cloud_sql/main.tf
@@ -66,7 +66,7 @@ resource "google_sql_database_instance" "default" {
 resource "google_secret_manager_secret" "dbuser" {
   secret_id = "dbusersecret"
   replication {
-    automatic = true
+    auto {}
   }
   depends_on = [google_project_service.secretmanager_api]
 }
@@ -93,7 +93,7 @@ resource "google_secret_manager_secret_iam_member" "secretaccess_compute_dbuser"
 resource "google_secret_manager_secret" "dbpass" {
   secret_id = "dbpasssecret"
   replication {
-    automatic = true
+    auto {}
   }
   depends_on = [google_project_service.secretmanager_api]
 }
@@ -119,7 +119,7 @@ resource "google_secret_manager_secret_iam_member" "secretaccess_compute_dbpass"
 resource "google_secret_manager_secret" "dbname" {
   secret_id = "dbnamesecret"
   replication {
-    automatic = true
+    auto {}
   }
   depends_on = [google_project_service.secretmanager_api]
 }

--- a/run/connect_cloud_sql/main.tf
+++ b/run/connect_cloud_sql/main.tf
@@ -16,6 +16,16 @@
 
 # Project data
 # [START cloudrun_connect_cloud_sql_parent_tag]
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0.0"
+    }
+  }
+}
+
 data "google_project" "project" {
 }
 

--- a/run/secret_manager/main.tf
+++ b/run/secret_manager/main.tf
@@ -24,7 +24,7 @@
 resource "google_secret_manager_secret" "default" {
   secret_id = "my-secret"
   replication {
-    automatic = true
+    auto {}
   }
 }
 

--- a/run/secret_manager/main.tf
+++ b/run/secret_manager/main.tf
@@ -21,6 +21,16 @@
 */
 
 # [START cloudrun_secret_manager_secret]
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0.0"
+    }
+  }
+}
+
 resource "google_secret_manager_secret" "default" {
   secret_id = "my-secret"
   replication {


### PR DESCRIPTION
With v5.0.0 of the Google provider, the parameter `automatic` for the [`google_secret_manager_secret` resource](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) has been deprecated in favor of the `auto` parameter. This PR replaces its use in 2 Cloud Run samples