### PR TITLE
fix(tests): skip samples with keyring resource

### DIFF
--- a/cloud_sql/instance_cmek/test.yaml
+++ b/cloud_sql/instance_cmek/test.yaml
@@ -1,0 +1,20 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintTest
+metadata:
+  name: instance_cmek
+spec:
+  skip: true

--- a/cloud_sql/mysql_instance_cmek/test.yaml
+++ b/cloud_sql/mysql_instance_cmek/test.yaml
@@ -1,0 +1,20 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintTest
+metadata:
+  name: mysql_instance_cmek
+spec:
+  skip: true

--- a/cloud_sql/postgres_instance_cmek/test.yaml
+++ b/cloud_sql/postgres_instance_cmek/test.yaml
@@ -1,0 +1,20 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintTest
+metadata:
+  name: postgres_instance_cmek
+spec:
+  skip: true

--- a/cloud_sql/sqlserver_instance_cmek/test.yaml
+++ b/cloud_sql/sqlserver_instance_cmek/test.yaml
@@ -1,0 +1,20 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintTest
+metadata:
+  name: sqlserver_instance_cmek
+spec:
+  skip: true


### PR DESCRIPTION
This PR will skip integration tests for cloud sql samples that use the `google_kms_key_ring` resource due to it causing integration tests to fail.

Fixes #504 