### PR TITLE
fix(tests): add directory prune to int build config

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
 - id: prune unchanged directories
   name: gcr.io/cloud-builders/git
   entrypoint: bash
-  args: 
+  args:
     - -c
     - |
       git fetch --unshallow

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -24,7 +24,7 @@ steps:
       git diff origin/${_BASE_BRANCH}..origin/${_HEAD_BRANCH} --name-only > _changed_files
       sed 's/\/.*/\//' _changed_files > _changed_folders
       for d in */; do
-          if ! grep -q ^$d _changed_folders; then
+          if ! grep -q "^$d" _changed_folders && [[ "$d" != "test/" ]]; then
             rm -rf $d;
           fi
       done

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -14,6 +14,20 @@
 
 timeout: 14400s
 steps:
+- id: prune unchanged directories
+  name: gcr.io/cloud-builders/git
+  entrypoint: bash
+  args: 
+    - -c
+    - | 
+      git fetch --unshallow
+      git diff origin/${_BASE_BRANCH}..origin/${_HEAD_BRANCH} --name-only > _changed_files
+      sed 's/\/.*/\//' _changed_files > _changed_folders
+      for d in */; do
+          if ! grep -q ^$d _changed_folders; then
+            rm -rf $d;
+          fi
+      done
 - id: prepare
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && prepare_environment']

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -19,7 +19,7 @@ steps:
   entrypoint: bash
   args: 
     - -c
-    - | 
+    - |
       git fetch --unshallow
       git diff origin/${_BASE_BRANCH}..origin/${_HEAD_BRANCH} --name-only > _changed_files
       sed 's/\/.*/\//' _changed_files > _changed_folders

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -14,6 +14,20 @@
 
 timeout: 3600s
 steps:
+- id: prune unchanged directories
+  name: gcr.io/cloud-builders/git
+  entrypoint: bash
+  args: 
+    - -c
+    - | 
+      git fetch --unshallow
+      git diff origin/${_BASE_BRANCH}..origin/${_HEAD_BRANCH} --name-only > _changed_files
+      sed 's/\/.*/\//' _changed_files > _changed_folders
+      for d in */; do
+          if ! grep -q "^$d" _changed_folders && [[ "$d" != "test/" ]]; then
+            rm -rf $d;
+          fi
+      done
 - id: lint-placeholder
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/usr/local/bin/test_lint.sh']

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -14,20 +14,6 @@
 
 timeout: 3600s
 steps:
-- id: prune unchanged directories
-  name: gcr.io/cloud-builders/git
-  entrypoint: bash
-  args: 
-    - -c
-    - | 
-      git fetch --unshallow
-      git diff origin/${_BASE_BRANCH}..origin/${_HEAD_BRANCH} --name-only > _changed_files
-      sed 's/\/.*/\//' _changed_files > _changed_folders
-      for d in */; do
-          if ! grep -q "^$d" _changed_folders && [[ "$d" != "test/" ]]; then
-            rm -rf $d;
-          fi
-      done
 - id: lint-placeholder
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/usr/local/bin/test_lint.sh']


### PR DESCRIPTION
This PR will add an additional step to `int.cloudbuild.yaml` that will remove unaltered directories from the included int tests.



Based on [Running Cloud Build with Pull Request context](https://glasnt.com/blog/cloud-build-pull-request-context/)