### PR TITLE
Revert "fix(tests): add directory prune to int build config"

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -14,20 +14,6 @@
 
 timeout: 14400s
 steps:
-- id: prune unchanged directories
-  name: gcr.io/cloud-builders/git
-  entrypoint: bash
-  args:
-    - -c
-    - |
-      git fetch --unshallow
-      git diff origin/${_BASE_BRANCH}..origin/${_HEAD_BRANCH} --name-only > _changed_files
-      sed 's/\/.*/\//' _changed_files > _changed_folders
-      for d in */; do
-          if ! grep -q "^$d" _changed_folders && [[ "$d" != "test/" ]]; then
-            rm -rf $d;
-          fi
-      done
 - id: prepare
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && prepare_environment']


### PR DESCRIPTION
Reverts terraform-google-modules/terraform-docs-samples#508

With this change integration test unintentionally skip all directories instead of unchanged ones. Back to the drawing board.