### PR TITLE
docs(compute): Fix typo in the resource name

### DIFF
--- a/compute/zonal_mig_set_autoscaling_basic/main.tf
+++ b/compute/zonal_mig_set_autoscaling_basic/main.tf
@@ -24,7 +24,7 @@
 # [START compute_zonal_mig_set_autoscaling_basic_parent_tag]
 # [START compute_zonal_mig_set_autoscaling]
 resource "google_compute_autoscaler" "default" {
-  name   = "exmple-autoscaler"
+  name   = "example-autoscaler"
   zone   = "us-central1-f"
   target = google_compute_instance_group_manager.default.id
 


### PR DESCRIPTION
Changed resource named from 'exmple-autoscaler' to 'example-autoscaler'

No code changes!

## Description

Fixes #<ISSUE-NUMBER>

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [ ] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [ ] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [ ] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
