### PR TITLE
feat: add sample for grpc startup probe

### DIFF
--- a/run/healthchecks_startup_probe_grpc/main.tf
+++ b/run/healthchecks_startup_probe_grpc/main.tf
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# Enable Cloud Run API
+resource "google_project_service" "cloudrun_api" {
+  service            = "run.googleapis.com"
+  disable_on_destroy = false
+}
+
+# Create Cloud Run Container with gRPC startup probe
+#[START cloudrun_healthchecks_startup_probe_gRPC]
+resource "google_cloud_run_v2_service" "default" {
+  name     = "cloudrun-service-healthcheck"
+  location = "us-central1"
+
+  template {
+    containers {
+      # Note: Change to the name of your image
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+
+      startup_probe {
+        failure_threshold     = 5
+        initial_delay_seconds = 10
+        timeout_seconds       = 3
+        period_seconds        = 3
+
+        grpc {
+          # Note: Change to the name of your pre-existing grpc health status service
+          service = "grpc.health.v1.Health"
+        }
+      }
+    }
+  }
+}
+#[END cloudrun_healthchecks_startup_probe_gRPC]
+

--- a/run/healthchecks_startup_probe_grpc/main.tf
+++ b/run/healthchecks_startup_probe_grpc/main.tf
@@ -15,7 +15,7 @@
  */
 
 # Enable Cloud Run API
-resource "google_project_service" "cloudrun_api" {
+resource "google_project_service" "default" {
   service            = "run.googleapis.com"
   disable_on_destroy = false
 }

--- a/run/healthchecks_startup_probe_grpc/test.yaml
+++ b/run/healthchecks_startup_probe_grpc/test.yaml
@@ -1,0 +1,20 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintTest
+metadata:
+  name: cloud_run_service_healthchecks_startup_probe_grpc
+spec:
+  skip: true


### PR DESCRIPTION
## Description

Fixes b/315103435

This sample is untestable using the hello container, because it does not implement grpc healthchecks. (The grpc liveness probe sample does not override the startup probe, so it successfully deploys. Since this is a startup probe, the deployment will fail, so it is untestable using the default image.)

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [ ] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): https://cloud.google.com/run/docs/configuring/healthchecks#grpc-startup-probe

