### PR TITLE
feat(cloud_sql): Add cloud sql psc connectivity SQL server sample

### DIFF
--- a/cloud_sql/sqlserver_instance_psc/main.tf
+++ b/cloud_sql/sqlserver_instance_psc/main.tf
@@ -30,7 +30,7 @@ resource "google_sql_database_instance" "default" {
     ip_configuration {
       psc_config {
         psc_enabled               = true
-        allowed_consumer_projects = []
+        allowed_consumer_projects = [] # Add consumer project IDs here.
       }
       ipv4_enabled = false
     }

--- a/cloud_sql/sqlserver_instance_psc/main.tf
+++ b/cloud_sql/sqlserver_instance_psc/main.tf
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# [START cloud_sql_sqlserver_instance_psc]
+resource "google_sql_database_instance" "default" {
+  name             = "sqlserver-instance"
+  region           = "us-central1"
+  database_version = "SQLSERVER_2019_ENTERPRISE"
+  root_password    = "INSERT-PASSWORD-HERE"
+  settings {
+    tier              = "db-custom-2-7680"
+    availability_type = "REGIONAL"
+    backup_configuration {
+      enabled    = true
+      start_time = "20:55"
+    }
+    ip_configuration {
+      psc_config {
+        psc_enabled               = true
+        allowed_consumer_projects = []
+      }
+      ipv4_enabled = false
+    }
+  }
+  deletion_protection = false # Set to "true" to prevent destruction of the resource
+}
+# [END cloud_sql_sqlserver_instance_psc]
+
+# [START cloud_sql_sqlserver_instance_psc_endpoint]
+resource "google_compute_address" "default" {
+  name         = "psc-compute-address-${google_sql_database_instance.default.name}"
+  region       = "us-central1"
+  address_type = "INTERNAL"
+  subnetwork   = "default"     # Replace value with the name of the subnet here.
+  address      = "10.128.0.44" # Replace value with the IP address to reserve.
+}
+
+data "google_sql_database_instance" "default" {
+  name = resource.google_sql_database_instance.default.name
+}
+
+resource "google_compute_forwarding_rule" "default" {
+  name                  = "psc-forwarding-rule-${google_sql_database_instance.default.name}"
+  region                = "us-central1"
+  network               = "default"
+  ip_address            = google_compute_address.default.self_link
+  load_balancing_scheme = ""
+  target                = data.google_sql_database_instance.default.psc_service_attachment_link
+}
+# [END cloud_sql_sqlserver_instance_psc_endpoint]


### PR DESCRIPTION
## Description

Added documentation for managing SQL server psc connectivity on Cloud SQL instances.

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
