### PR TITLE
chore: switch to longer rand prefix for int test projects

### DIFF
--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -27,12 +27,13 @@ module "projects" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 14.0"
 
-  name                    = "ci-tf-samples-${count.index}"
-  random_project_id       = true
-  org_id                  = var.org_id
-  folder_id               = var.folder_id
-  billing_account         = var.billing_account
-  default_service_account = "keep"
+  name                      = "ci-tf-samples-${count.index}"
+  random_project_id         = true
+  random_project_id_length  = 8
+  org_id                    = var.org_id
+  folder_id                 = var.folder_id
+  billing_account           = var.billing_account
+  default_service_account   = "keep"
   // flask_google_cloud_quickstart, instance_virtual_display_enabled etc requires default network
   auto_create_network = true
 

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -27,13 +27,13 @@ module "projects" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 14.0"
 
-  name                      = "ci-tf-samples-${count.index}"
-  random_project_id         = true
-  random_project_id_length  = 8
-  org_id                    = var.org_id
-  folder_id                 = var.folder_id
-  billing_account           = var.billing_account
-  default_service_account   = "keep"
+  name                     = "ci-tf-samples-${count.index}"
+  random_project_id        = true
+  random_project_id_length = 8
+  org_id                   = var.org_id
+  folder_id                = var.folder_id
+  billing_account          = var.billing_account
+  default_service_account  = "keep"
   // flask_google_cloud_quickstart, instance_virtual_display_enabled etc requires default network
   auto_create_network = true
 


### PR DESCRIPTION
Underlying logic for random_project_id_length also uses `random_string` for a larger collusion domain so hopefully reduces collisions