### PR TITLE
feat: add enabling vertex ai api sample for documentation

### DIFF
--- a/vertex_ai/api/main.tf
+++ b/vertex_ai/api/main.tf
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# [START aiplatform_enable_vertex_ai_api]
+# Enable Vertex AI API
+resource "google_project_service" "default" {
+  service            = "aiplatform.googleapis.com"
+  disable_on_destroy = false
+}
+# [END aiplatform_enable_vertex_ai_api]


### PR DESCRIPTION
## Description

Fixes b/321690958

Add sample for enabling Vertex AI API for documentation.

Docs: https://cloud.google.com/vertex-ai/docs/start/cloud-environment#enable_vertexai_apis