### PR TITLE
docs: Introduce the ssl_mode into the MySQL SSL example

### DIFF
--- a/cloud_sql/mysql_instance_ssl_cert/main.tf
+++ b/cloud_sql/mysql_instance_ssl_cert/main.tf
@@ -22,7 +22,11 @@ resource "google_sql_database_instance" "mysql_instance" {
   settings {
     tier = "db-f1-micro"
     ip_configuration {
+      # The following SSL enforcement options only allow connections encrypted with SSL/TLS and with
+      # valid client certificates. Please check the API reference for other SSL enforcement options:
+      # https://cloud.google.com/sql/docs/postgres/admin-api/rest/v1beta4/instances#ipconfiguration
       require_ssl = "true"
+      ssl_mode    = "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
     }
   }
   # set `deletion_protection` to true, will ensure that one cannot accidentally delete this instance by


### PR DESCRIPTION
We have introduced `ssl_mode` to MySQL instances. Thus its SSL example should be updated too.

## Description

Fixes #313530521

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): https://cloud.google.com/sql/docs/mysql/configure-ssl-instance#terraform

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
