### PR TITLE
fix: Removing optional flags from the command to create an instance template for GPU VMs

### DIFF
--- a/compute/instance_template_with_gpu/main.tf
+++ b/compute/instance_template_with_gpu/main.tf
@@ -17,12 +17,10 @@
  * Made to resemble
  * gcloud compute instance-templates create gpu-template \
  * --machine-type n1-standard-2 \
- * --boot-disk-size 250GB \
  * --accelerator type=nvidia-tesla-t4,count=1 \
  * --image-family debian-11 \
  * --image-project debian-cloud \
- * --maintenance-policy TERMINATE \
- * --restart-on-failure
+ * --maintenance-policy TERMINATE
 */
 
 # [START compute_template_gpu]
@@ -32,20 +30,19 @@ resource "google_compute_instance_template" "default" {
 
   disk {
     source_image = "debian-cloud/debian-11"
-    disk_size_gb = 250
   }
 
   network_interface {
     network = "default"
   }
+
   guest_accelerator {
     type  = "nvidia-tesla-t4"
     count = 1
   }
+
   scheduling {
-    automatic_restart   = true
     on_host_maintenance = "TERMINATE"
   }
-
 }
 # [END compute_template_gpu]


### PR DESCRIPTION
## Description

Fixes b/320434395

## Checklist

**Readiness**

- [ ] Yes, **merge** this PR after it is approved
- [x] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):
     - https://cloud.google.com/compute/docs/samples/compute-template-gpu
     - https://cloud.google.com/compute/docs/instance-templates/create-instance-templates

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
