### PR TITLE
fix: prevent application of workflows/cloud_run_job

### DIFF
--- a/workflows/cloud_run_job/test.yaml
+++ b/workflows/cloud_run_job/test.yaml
@@ -1,0 +1,20 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintTest
+metadata:
+  name: cloud_run_job
+spec:
+  skip: true


### PR DESCRIPTION
## Description

Fixes #605, #606

This test correctly identifies the image that is created in the tutorial, but that image is per-project, and not created in tests. 

Simplest way to prevent perioidic testing issues is to disable this sample from being tested. 

(Alternative is to edit the workflow image to be `hello`, which will require user editing, but as the workflow is only provisioned and not executed, this would be successful as far as `terraform apply` is concerned.)


## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)
