### PR TITLE
feat: add gke standard samples

### DIFF
--- a/gke/standard/regional/multi-zone/main.tf
+++ b/gke/standard/regional/multi-zone/main.tf
@@ -1,0 +1,28 @@
+/**
+* Copyright 2024 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+# [START gke_standard_regional_multi_zone]
+resource "google_container_cluster" "default" {
+  name               = "gke-standard-regional-multi-zone"
+  location           = "us-central1"
+  node_locations     = ["us-central1-b", "us-central1-c"]
+  initial_node_count = 2
+
+  # Set `deletion_protection` to `true` will ensure that one cannot
+  # accidentally delete this instance by use of Terraform.
+  deletion_protection = false
+}
+# [END gke_standard_regional_multi_zone]

--- a/gke/standard/regional/single-zone/main.tf
+++ b/gke/standard/regional/single-zone/main.tf
@@ -1,0 +1,28 @@
+/**
+* Copyright 2024 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+# [START gke_standard_regional_single_zone]
+resource "google_container_cluster" "default" {
+  name               = "gke-standard-regional-single-zone"
+  location           = "us-west1"
+  node_locations     = ["us-west1-c"]
+  initial_node_count = 2
+
+  # Set `deletion_protection` to `true` will ensure that one cannot
+  # accidentally delete this instance by use of Terraform.
+  deletion_protection = false
+}
+# [END gke_standard_regional_single_zone]

--- a/gke/standard/zonal/multi-zone/main.tf
+++ b/gke/standard/zonal/multi-zone/main.tf
@@ -1,0 +1,28 @@
+/**
+* Copyright 2024 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+# [START gke_standard_zonal_multi_zone]
+resource "google_container_cluster" "default" {
+  name               = "gke-standard-zonal-multi-zone"
+  location           = "us-central1-a"
+  node_locations     = ["us-central1-b", "us-central1-c"]
+  initial_node_count = 2
+
+  # Set `deletion_protection` to `true` will ensure that one cannot
+  # accidentally delete this instance by use of Terraform.
+  deletion_protection = false
+}
+# [END gke_standard_zonal_multi_zone]

--- a/gke/standard/zonal/single-zone/main.tf
+++ b/gke/standard/zonal/single-zone/main.tf
@@ -1,0 +1,27 @@
+/**
+* Copyright 2024 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+# [START gke_standard_zonal_single_zone]
+resource "google_container_cluster" "default" {
+  name               = "gke-standard-zonal-single-zone"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  # Set `deletion_protection` to `true` will ensure that one cannot
+  # accidentally delete this instance by use of Terraform.
+  deletion_protection = false
+}
+# [END gke_standard_zonal_single_zone]


### PR DESCRIPTION
## Description

Adds the following samples:
- GKE Standard Zonal
  - Single-Zone
  - Multi-Zone
- GKE Standard Regional
  - Single-Zone
  - Multi-Zone

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):
  - https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-zonal-cluster
  - https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-regional-cluster

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [x] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [x] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
