### PR TITLE
fix: Fix inconsistent quotes in mig hc examples

### DIFF
--- a/compute/firewall_rule_for_health_check/main.tf
+++ b/compute/firewall_rule_for_health_check/main.tf
@@ -29,7 +29,7 @@ resource "google_compute_firewall" "default" {
   source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
   allow {
     protocol = "tcp"
-    ports    = ["80"]
+    ports    = [80]
   }
 }
 # [END compute_firewall_rule_for_health_check_tag]

--- a/compute/health_check/main.tf
+++ b/compute/health_check/main.tf
@@ -30,6 +30,6 @@ resource "google_compute_http_health_check" "default" {
   check_interval_sec  = 30
   healthy_threshold   = 1
   unhealthy_threshold = 3
-  port                = "80"
+  port                = 80
 }
 # [END compute_health_check_tag]

--- a/compute/zonal_mig_health_check/main.tf
+++ b/compute/zonal_mig_health_check/main.tf
@@ -41,7 +41,7 @@ resource "google_compute_http_health_check" "default" {
   check_interval_sec  = 30
   healthy_threshold   = 1
   unhealthy_threshold = 3
-  port                = "80"
+  port                = 80
 }
 
 resource "google_compute_firewall" "default" {
@@ -50,7 +50,7 @@ resource "google_compute_firewall" "default" {
   source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
   allow {
     protocol = "tcp"
-    ports    = ["80"]
+    ports    = [80]
   }
 }
 


### PR DESCRIPTION
## Description

Fixes #216660554

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): https://cloud.google.com/compute/docs/instance-groups/autohealing-instances-in-migs

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [x] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [x] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
