### PR TITLE
chore: enable local parallel lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-# Pin to 1.3.9 per https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/1208
 DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.19
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
@@ -70,6 +69,7 @@ docker_test_integration:
 .PHONY: docker_test_lint
 docker_test_lint:
 	$(DOCKER_BIN) run --rm -it \
+		-e ENABLE_PARALLEL=1 \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/usr/local/bin/test_lint.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2022-2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

enable `make_docker_lint` to run tf validate in parallel