### PR TITLE
fix: add GKE cluster into snippet tag

### DIFF
--- a/gke/autopilot/tag/main.tf
+++ b/gke/autopilot/tag/main.tf
@@ -14,8 +14,7 @@
 * limitations under the License.
 */
 
-data "google_project" "default" {}
-
+# [START gke_autopilot_tag]
 resource "google_container_cluster" "default" {
   name     = "gke-autopilot-tag"
   location = "us-central1"
@@ -27,7 +26,8 @@ resource "google_container_cluster" "default" {
   deletion_protection = false
 }
 
-# [START gke_autopilot_tag]
+data "google_project" "default" {}
+
 resource "google_tags_tag_key" "default" {
   parent      = "projects/${data.google_project.default.project_id}"
   short_name  = "env"


### PR DESCRIPTION
## Description
- add GKE cluster into snippet region tag

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [ ] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): (existing sample)

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [x] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [x] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
