### PR TITLE
chore: increase periodic test timeout to 6 hours

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-timeout: 14400s
+timeout: 21600s
 steps:
 - id: prune unchanged directories
   name: gcr.io/cloud-builders/git


### PR DESCRIPTION
## Description

The trigger `terraform-docs-samples-periodic-int-trigger` has been failing due to timeout. 

This PR increases the timeout for this config from 4 hours to 6 hours. 

Noting that this configuration is run for both PR tests and nightly periodic tests, so the timeout applies for both. 