### PR TITLE
feat(GKE): Add secondary boot disk sample for preloaded data

### DIFF
--- a/gke/standard/zonal/secondary-boot-disk/main.tf
+++ b/gke/standard/zonal/secondary-boot-disk/main.tf
@@ -21,8 +21,8 @@ resource "google_container_cluster" "default" {
   initial_node_count = 1
   # Set `min_master_version` because secondary_boot_disks require GKE 1.28.3-gke.106700 or later.
   min_master_version = "1.28"
-  # Set `deletion_protection` to `true` so that one cannot
-  # accidentally delete this instance using Terraform.
+  # Setting `deletion_protection` to `true` would prevent
+  # accidental deletion of this instance using Terraform.
   deletion_protection = false
 }
 # [END gke_standard_zonal_secondary_boot_disk_cluster]

--- a/gke/standard/zonal/secondary-boot-disk/main.tf
+++ b/gke/standard/zonal/secondary-boot-disk/main.tf
@@ -28,8 +28,8 @@ resource "google_container_cluster" "default" {
 # [END gke_standard_zonal_secondary_boot_disk_cluster]
 
 # [START gke_standard_zonal_secondary_boot_disk_container]
-resource "google_container_node_pool" "secondary_boot_disk_container" {
-  name               = "secondary_boot_disk_container"
+resource "google_container_node_pool" "secondary-boot-disk-container" {
+  name               = "secondary-boot-disk-container"
   location           = "us-central1-a"
   cluster            = google_container_cluster.default.name
   initial_node_count = 1
@@ -49,8 +49,8 @@ resource "google_container_node_pool" "secondary_boot_disk_container" {
 # [END gke_standard_zonal_secondary_boot_disk_container]
 
 # [START gke_standard_zonal_secondary_boot_disk_data]
-resource "google_container_node_pool" "secondary_boot_disk_data" {
-  name               = "secondary_boot_disk_data"
+resource "google_container_node_pool" "secondary-boot-disk-data" {
+  name               = "secondary-boot-disk-data"
   location           = "us-central1-a"
   cluster            = google_container_cluster.default.name
   initial_node_count = 1

--- a/gke/standard/zonal/secondary-boot-disk/main.tf
+++ b/gke/standard/zonal/secondary-boot-disk/main.tf
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-# [START gke_standard_zonal_secondary_boot_disk]
+# [START gke_standard_zonal_secondary_boot_disk_cluster]
 resource "google_container_cluster" "default" {
   name               = "default"
   location           = "us-central1-a"
@@ -25,9 +25,11 @@ resource "google_container_cluster" "default" {
   # accidentally delete this instance by use of Terraform.
   deletion_protection = false
 }
+# [END gke_standard_zonal_secondary_boot_disk_cluster]
 
-resource "google_container_node_pool" "default" {
-  name               = "default"
+# [START gke_standard_zonal_secondary_boot_disk_container]
+resource "google_container_node_pool" "secondary_boot_disk_container" {
+  name               = "secondary_boot_disk_container"
   location           = "us-central1-a"
   cluster            = google_container_cluster.default.name
   initial_node_count = 1
@@ -44,22 +46,11 @@ resource "google_container_node_pool" "default" {
     }
   }
 }
-# [END gke_standard_zonal_secondary_boot_disk]
+# [END gke_standard_zonal_secondary_boot_disk_container]
 
 # [START gke_standard_zonal_secondary_boot_disk_data]
-resource "google_container_cluster" "default" {
-  name               = "default"
-  location           = "us-central1-a"
-  initial_node_count = 1
-  # Set `min_master_version` because secondary_boot_disks require GKE 1.28.3-gke.106700 or later
-  min_master_version = "1.28"
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
-}
-
-resource "google_container_node_pool" "default" {
-  name               = "default"
+resource "google_container_node_pool" "secondary_boot_disk_data" {
+  name               = "secondary_boot_disk_data"
   location           = "us-central1-a"
   cluster            = google_container_cluster.default.name
   initial_node_count = 1

--- a/gke/standard/zonal/secondary-boot-disk/main.tf
+++ b/gke/standard/zonal/secondary-boot-disk/main.tf
@@ -45,3 +45,34 @@ resource "google_container_node_pool" "default" {
   }
 }
 # [END gke_standard_zonal_secondary_boot_disk]
+
+# [START gke_standard_zonal_secondary_boot_disk_data]
+resource "google_container_cluster" "default" {
+  name               = "default"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  # Set `min_master_version` because secondary_boot_disks require GKE 1.28.3-gke.106700 or later
+  min_master_version = "1.28"
+  # Set `deletion_protection` to `true` will ensure that one cannot
+  # accidentally delete this instance by use of Terraform.
+  deletion_protection = false
+}
+
+resource "google_container_node_pool" "default" {
+  name               = "default"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.default.name
+  initial_node_count = 1
+
+  node_config {
+    machine_type = "e2-medium"
+    image_type   = "COS_CONTAINERD"
+    gcfs_config {
+      enabled = true
+    }
+    secondary_boot_disks {
+      disk_image = ""
+    }
+  }
+}
+# [END gke_standard_zonal_secondary_boot_disk_data]

--- a/gke/standard/zonal/secondary-boot-disk/main.tf
+++ b/gke/standard/zonal/secondary-boot-disk/main.tf
@@ -19,10 +19,10 @@ resource "google_container_cluster" "default" {
   name               = "default"
   location           = "us-central1-a"
   initial_node_count = 1
-  # Set `min_master_version` because secondary_boot_disks require GKE 1.28.3-gke.106700 or later
+  # Set `min_master_version` because secondary_boot_disks require GKE 1.28.3-gke.106700 or later.
   min_master_version = "1.28"
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
+  # Set `deletion_protection` to `true` so that one cannot
+  # accidentally delete this instance using Terraform.
   deletion_protection = false
 }
 # [END gke_standard_zonal_secondary_boot_disk_cluster]


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): https://cloud.google.com/kubernetes-engine/docs/how-to/data-container-image-preloading

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [x] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [x] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
