### PR TITLE
feat(compute): Added example for mig standby policy

### DIFF
--- a/compute/zonal_mig_standby_policy/main.tf
+++ b/compute/zonal_mig_standby_policy/main.tf
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** Made to resemble
+ * gcloud beta compute instance-groups managed update standby-mig \
+ * --standby-policy-mode=scale-out-pool \
+ * --standby-policy-initial-delay=50 \
+ * --zone=us-central1-f
+ */
+# [START compute_zonal_instance_group_manager_standby_policy_parent_tag]
+resource "google_compute_instance_template" "default" {
+  name         = "an-instance-template"
+  machine_type = "e2-medium"
+
+  disk {
+    source_image = "debian-cloud/debian-11"
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+
+# [START compute_zonal_instance_group_manager_standby_policy_tag]
+resource "google_compute_instance_group_manager" "default" {
+  provider           = google-beta
+  name               = "standby-mig"
+  base_instance_name = "test"
+  target_size        = 3
+  zone               = "us-central1-f"
+
+  version {
+    instance_template = google_compute_instance_template.default.id
+    name              = "primary"
+  }
+  standby_policy {
+    initial_delay_sec = 50
+    mode              = "SCALE_OUT_POOL"
+  }
+}
+# [END compute_zonal_instance_group_manager_standby_policy_tag]
+# [END compute_zonal_instance_group_manager_standby_policy_parent_tag]


### PR DESCRIPTION
## Description

Fixes #335382497

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): https://cloud.google.com/compute/docs/instance-groups/accelerate-mig-scale-out-with-standby-pools#edit_the_standby_policy_in_a_mig

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [x] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [x] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
