### PR TITLE
docs: Add Managed Kafka terraform samples for Clusters and Topics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,3 +25,4 @@
 /vertex_ai/             @terraform-google-modules/dee-data-ai @terraform-google-modules/terraform-samples-reviewers
 /vpc/                   @terraform-google-modules/dee-infra @terraform-google-modules/terraform-samples-reviewers
 /workflows/             @terraform-google-modules/torus-dpe @terraform-google-modules/terraform-samples-reviewers
+/managedkafka/          @terraform-google-modules/managedkafka-dev-team @terraform-google-modules/terraform-samples-reviewers

--- a/managedkafka/managedkafka_create_cluster/main.tf
+++ b/managedkafka/managedkafka_create_cluster/main.tf
@@ -38,3 +38,4 @@ data "google_project" "default" {
   provider = google-beta
 }
 # [END managedkafka_create_cluster_parent]
+

--- a/managedkafka/managedkafka_create_cluster/main.tf
+++ b/managedkafka/managedkafka_create_cluster/main.tf
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# [START managedkafka_create_cluster_parent]
+# [START managedkafka_create_cluster]
+resource "google_managed_kafka_cluster" "default" {
+  provider   = google-beta
+  cluster_id = "my-cluster-id"
+  location   = "us-central1"
+  capacity_config {
+    vcpu_count   = 3
+    memory_bytes = 3221225472
+  }
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/${data.google_project.default.number}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+}
+# [END managedkafka_create_cluster]
+
+data "google_project" "default" {
+  provider = google-beta
+}
+# [END managedkafka_create_cluster_parent]

--- a/managedkafka/managedkafka_create_cluster/main.tf
+++ b/managedkafka/managedkafka_create_cluster/main.tf
@@ -38,4 +38,3 @@ data "google_project" "default" {
   provider = google-beta
 }
 # [END managedkafka_create_cluster_parent]
-

--- a/managedkafka/managedkafka_create_topic/main.tf
+++ b/managedkafka/managedkafka_create_topic/main.tf
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# [START managedkafka_create_topic_parent]
+resource "google_managed_kafka_cluster" "default" {
+  provider   = google-beta
+  cluster_id = "my-cluster-id"
+  location   = "us-central1"
+  capacity_config {
+    vcpu_count   = 3
+    memory_bytes = 3221225472
+  }
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/${data.google_project.default.number}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+}
+
+# [START managedkafka_create_topic]
+resource "google_managed_kafka_topic" "default" {
+  provider           = google-beta
+  topic_id           = "my-topic-id"
+  cluster            = google_managed_kafka_cluster.default.cluster_id
+  location           = "us-central1"
+  partition_count    = 2
+  replication_factor = 3
+}
+# [END managedkafka_create_topic]
+
+data "google_project" "default" {
+  provider = google-beta
+}
+# [END managedkafka_create_topic_parent]

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -77,6 +77,7 @@ module "projects" {
     "workflows.googleapis.com",
     "osconfig.googleapis.com",
     "connectors.googleapis.com",
-    "bigqueryreservation.googleapis.com"
+    "bigqueryreservation.googleapis.com",
+    "managedkafka.googleapis.com"
   ]
 }


### PR DESCRIPTION
## Description

Fixes https://b.corp.google.com/issues/343411931

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): https://cloud.google.com/managed-kafka/docs

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [x] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [x] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)