### PR TITLE
Revert "chore(CI): parallel lint"

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -43,4 +43,4 @@ jobs:
             REGISTRY=$(grep "REGISTRY_URL := " $MAKEFILE | cut -d\  -f3)
             echo dev-tools=${REGISTRY}/${IMAGE}:${VERSION} >> "$GITHUB_OUTPUT"
           fi
-      - run: docker run --rm -e ENABLE_PARALLEL=1 -e TF_PLUGIN_CACHE_DIR= -v ${{ github.workspace }}:/workspace ${{ steps.variables.outputs.dev-tools }} /usr/local/bin/test_lint.sh
+      - run: docker run --rm -v ${{ github.workspace }}:/workspace ${{ steps.variables.outputs.dev-tools }} /usr/local/bin/test_lint.sh


### PR DESCRIPTION
Reverts terraform-google-modules/terraform-docs-samples#672

Recently, linting checks have been erroring with disk space errors: `No space left on device`. This is blocking PRs from being merged. E.g. https://github.com/terraform-google-modules/terraform-docs-samples/actions/runs/9581832081/attempts/3?pr=696

The change in #672 introduced using a variable that through cft/developer-tools uses `parallel`, but also changed the value for TF_PLUGIN_CACHE_DIR, a variable that configures [plugin caching](https://developer.hashicorp.com/terraform/cli/config/config-file#provider-plugin-cache), from the cft/developer-tools default, to not using one. 

Since linting is occurring at a per sample level, without the cache, the provider is being downloaded to the local `.terraform/` directory, at a size of ~100MB per instance. Multiply this by 300+ samples, and the GitHub Action runner runs out of diskspace. 

It doesn't look like `parallel` and caching can work together, because I've observed the following errors in my debugging: 

```
Error while installing hashicorp/google v5.34.0: open
│ /workspace/test/integration/tmp/.terraform/registry.terraform.io/hashicorp/google/5.34.0/linux_amd64/terraform-provider-google_v5.34.0_x5:
│ text file busy
```

This looks similar to the errors in https://github.com/terraform-google-modules/terraform-docs-samples/actions/runs/9162731674/job/25190305562, the first commit of the original PR, where the next commit removes the cache. 

I appreciate the tests being faster, but given linting would previously take ~10 mins and integration tests take about that long to setup, parallelisation being added to integration is probably a better performance improvement. 