### PR TITLE
feat: make force_destroy configurable

### DIFF
--- a/storage/remote_terraform_backend_template/README.md
+++ b/storage/remote_terraform_backend_template/README.md
@@ -16,12 +16,12 @@ To run this example, do the following:
 
     terraform init -migrate-state
 
-
-
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| terraform\_state\_bucket\_force\_destroy | Set this to true to enable destroying the Terraform remote state Cloud Storage bucket | `bool` | `false` | no |
 
 ## Outputs
 

--- a/storage/remote_terraform_backend_template/main.tf
+++ b/storage/remote_terraform_backend_template/main.tf
@@ -22,7 +22,7 @@ resource "google_storage_bucket" "default" {
   name     = "${random_id.default.hex}-terraform-remote-backend"
   location = "US"
 
-  force_destroy               = false
+  force_destroy               = var.terraform_state_bucket_force_destroy
   public_access_prevention    = "enforced"
   uniform_bucket_level_access = true
 
@@ -30,6 +30,13 @@ resource "google_storage_bucket" "default" {
     enabled = true
   }
 }
+
+variable "terraform_state_bucket_force_destroy" {
+  description = "Set this to true to enable destroying the Terraform remote state Cloud Storage bucket"
+  default     = false
+  type        = bool
+}
+
 # [END storage_bucket_tf_with_versioning_pap_uap_no_destroy]
 
 # [START storage_remote_backend_local_file]


### PR DESCRIPTION
## Description

Use a variable to set the force_destroy attribute of the Cloud Storage bucket to store the Terraform state. This is helpful to simplify the related tutorial because we can ask users to adjust the value of the variable, instead of asking them to modify the source code.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
