### PR TITLE
chore: revert "feat: make force_destroy configurable (#703)"

### DIFF
--- a/storage/remote_terraform_backend_template/README.md
+++ b/storage/remote_terraform_backend_template/README.md
@@ -16,12 +16,12 @@ To run this example, do the following:
 
     terraform init -migrate-state
 
+
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| terraform\_state\_bucket\_force\_destroy | Set this to true to enable destroying the Terraform remote state Cloud Storage bucket | `bool` | `false` | no |
+No inputs.
 
 ## Outputs
 

--- a/storage/remote_terraform_backend_template/main.tf
+++ b/storage/remote_terraform_backend_template/main.tf
@@ -22,7 +22,7 @@ resource "google_storage_bucket" "default" {
   name     = "${random_id.default.hex}-terraform-remote-backend"
   location = "US"
 
-  force_destroy               = var.terraform_state_bucket_force_destroy
+  force_destroy               = false
   public_access_prevention    = "enforced"
   uniform_bucket_level_access = true
 
@@ -30,13 +30,6 @@ resource "google_storage_bucket" "default" {
     enabled = true
   }
 }
-
-variable "terraform_state_bucket_force_destroy" {
-  description = "Set this to true to enable destroying the Terraform remote state Cloud Storage bucket"
-  default     = false
-  type        = bool
-}
-
 # [END storage_bucket_tf_with_versioning_pap_uap_no_destroy]
 
 # [START storage_remote_backend_local_file]


### PR DESCRIPTION
## Description

This reverts commit da45049037192709f185cd4e425acbfaa768d43c.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [ ] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [ ] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [ ] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [ ] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
