### PR TITLE
fix: Update debian-10 to debian-12

### DIFF
--- a/compute/basic_vm/main.tf
+++ b/compute/basic_vm/main.tf
@@ -69,7 +69,7 @@ resource "google_compute_instance" "custom_subnet" {
   }
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-10"
+      image = "debian-cloud/debian-12"
     }
   }
 }

--- a/compute/packet_mirroring_full/main.tf
+++ b/compute/packet_mirroring_full/main.tf
@@ -103,7 +103,7 @@ resource "google_compute_instance_template" "instance_template" {
     }
   }
   disk {
-    source_image = "debian-cloud/debian-10"
+    source_image = "debian-cloud/debian-12"
     auto_delete  = true
     boot         = true
   }
@@ -216,7 +216,7 @@ resource "google_compute_instance" "vm_test" {
   }
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-10"
+      image = "debian-cloud/debian-12"
     }
   }
 }

--- a/lb/external_http_lb_mig_backend_custom_header/main.tf
+++ b/lb/external_http_lb_mig_backend_custom_header/main.tf
@@ -99,7 +99,7 @@ resource "google_compute_instance_template" "default" {
     }
   }
   disk {
-    source_image = "debian-cloud/debian-10"
+    source_image = "debian-cloud/debian-12"
     auto_delete  = true
     boot         = true
   }

--- a/lb/external_ssl_proxy_lb_mig_backend/main.tf
+++ b/lb/external_ssl_proxy_lb_mig_backend/main.tf
@@ -136,7 +136,7 @@ resource "google_compute_instance_template" "default" {
     }
   }
   disk {
-    source_image = "debian-cloud/debian-10"
+    source_image = "debian-cloud/debian-12"
     auto_delete  = true
     boot         = true
   }

--- a/lb/external_ssl_proxy_lb_mig_backend_custom_header/main.tf
+++ b/lb/external_ssl_proxy_lb_mig_backend_custom_header/main.tf
@@ -136,7 +136,7 @@ resource "google_compute_instance_template" "default" {
     }
   }
   disk {
-    source_image = "debian-cloud/debian-10"
+    source_image = "debian-cloud/debian-12"
     auto_delete  = true
     boot         = true
   }

--- a/lb/external_tcp_proxy_lb_mig_backend/main.tf
+++ b/lb/external_tcp_proxy_lb_mig_backend/main.tf
@@ -99,7 +99,7 @@ resource "google_compute_instance_template" "default" {
     }
   }
   disk {
-    source_image = "debian-cloud/debian-10"
+    source_image = "debian-cloud/debian-12"
     auto_delete  = true
     boot         = true
   }

--- a/lb/external_tcp_proxy_lb_mig_backend_custom_header/main.tf
+++ b/lb/external_tcp_proxy_lb_mig_backend_custom_header/main.tf
@@ -99,7 +99,7 @@ resource "google_compute_instance_template" "default" {
     }
   }
   disk {
-    source_image = "debian-cloud/debian-10"
+    source_image = "debian-cloud/debian-12"
     auto_delete  = true
     boot         = true
   }

--- a/lb/int_https_lb_https_redirect/main.tf
+++ b/lb/int_https_lb_https_redirect/main.tf
@@ -153,7 +153,7 @@ resource "google_compute_instance_template" "default" {
     }
   }
   disk {
-    source_image = "debian-cloud/debian-10"
+    source_image = "debian-cloud/debian-12"
     auto_delete  = true
     boot         = true
   }
@@ -246,7 +246,7 @@ resource "google_compute_instance" "default" {
   }
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-10"
+      image = "debian-cloud/debian-12"
     }
   }
 }

--- a/lb/internal_http_lb_with_mig_backend/main.tf
+++ b/lb/internal_http_lb_with_mig_backend/main.tf
@@ -106,7 +106,7 @@ resource "google_compute_instance_template" "instance_template" {
     }
   }
   disk {
-    source_image = "debian-cloud/debian-10"
+    source_image = "debian-cloud/debian-12"
     auto_delete  = true
     boot         = true
   }
@@ -200,7 +200,7 @@ resource "google_compute_instance" "vm_test" {
   }
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-10"
+      image = "debian-cloud/debian-12"
     }
   }
 }

--- a/lb/internal_tcp_udp_lb_with_mig_backend/main.tf
+++ b/lb/internal_tcp_udp_lb_with_mig_backend/main.tf
@@ -76,7 +76,7 @@ resource "google_compute_instance_template" "instance_template" {
     }
   }
   disk {
-    source_image = "debian-cloud/debian-10"
+    source_image = "debian-cloud/debian-12"
     auto_delete  = true
     boot         = true
   }
@@ -193,7 +193,7 @@ resource "google_compute_instance" "vm_test" {
   }
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-10"
+      image = "debian-cloud/debian-12"
     }
   }
 }

--- a/lb/regional_external_http_load_balancer/main.tf
+++ b/lb/regional_external_http_load_balancer/main.tf
@@ -92,7 +92,7 @@ resource "google_compute_instance_template" "default" {
     boot         = true
     device_name  = "persistent-disk-0"
     mode         = "READ_WRITE"
-    source_image = "projects/debian-cloud/global/images/family/debian-10"
+    source_image = "projects/debian-cloud/global/images/family/debian-12"
     type         = "PERSISTENT"
   }
   labels = {

--- a/lb/shared_vpc_http_ilb_with_mig_backend/main.tf
+++ b/lb/shared_vpc_http_ilb_with_mig_backend/main.tf
@@ -177,7 +177,7 @@ resource "google_compute_instance_template" "default" {
     }
   }
   disk {
-    source_image = "debian-cloud/debian-10"
+    source_image = "debian-cloud/debian-12"
     auto_delete  = true
     boot         = true
   }
@@ -257,7 +257,7 @@ resource "google_compute_instance" "test_vm" {
   }
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-10"
+      image = "debian-cloud/debian-12"
     }
   }
   lifecycle {

--- a/lb/shared_vpc_http_ilb_with_mig_backend_basic_example/main.tf
+++ b/lb/shared_vpc_http_ilb_with_mig_backend_basic_example/main.tf
@@ -144,7 +144,7 @@ resource "google_compute_instance_template" "default" {
     }
   }
   disk {
-    source_image = "debian-cloud/debian-10"
+    source_image = "debian-cloud/debian-12"
     auto_delete  = true
     boot         = true
   }
@@ -278,7 +278,7 @@ resource "google_compute_instance" "vm_test" {
   }
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-10"
+      image = "debian-cloud/debian-12"
     }
   }
   lifecycle {

--- a/lb/shared_vpc_http_ilb_with_mig_backend_cross_reference_example/main.tf
+++ b/lb/shared_vpc_http_ilb_with_mig_backend_cross_reference_example/main.tf
@@ -156,7 +156,7 @@ resource "google_compute_instance_template" "default" {
     }
   }
   disk {
-    source_image = "debian-cloud/debian-10"
+    source_image = "debian-cloud/debian-12"
     auto_delete  = true
     boot         = true
   }
@@ -290,7 +290,7 @@ resource "google_compute_instance" "vm_test" {
   }
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-10"
+      image = "debian-cloud/debian-12"
     }
   }
   lifecycle {

--- a/lb/shared_vpc_https_ilb_with_mig_backend_basic_example/main.tf
+++ b/lb/shared_vpc_https_ilb_with_mig_backend_basic_example/main.tf
@@ -144,7 +144,7 @@ resource "google_compute_instance_template" "default" {
     }
   }
   disk {
-    source_image = "debian-cloud/debian-10"
+    source_image = "debian-cloud/debian-12"
     auto_delete  = true
     boot         = true
   }
@@ -291,7 +291,7 @@ resource "google_compute_instance" "vm_test" {
   }
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-10"
+      image = "debian-cloud/debian-12"
     }
   }
   lifecycle {

--- a/lb/shared_vpc_https_ilb_with_mig_backend_cross_reference_example/main.tf
+++ b/lb/shared_vpc_https_ilb_with_mig_backend_cross_reference_example/main.tf
@@ -156,7 +156,7 @@ resource "google_compute_instance_template" "default" {
     }
   }
   disk {
-    source_image = "debian-cloud/debian-10"
+    source_image = "debian-cloud/debian-12"
     auto_delete  = true
     boot         = true
   }
@@ -303,7 +303,7 @@ resource "google_compute_instance" "vm_test" {
   }
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-10"
+      image = "debian-cloud/debian-12"
     }
   }
   lifecycle {


### PR DESCRIPTION
## Description

* On June 30, `debian-10` reached end-of-life. See [source](https://www.debian.org/News/2024/20240615#:~:text=The%20Debian%20Long%20Term%20Support,security%20updates%20for%20Debian%2010.).
* We will need to update Terraform samples that use `debian-10` to use `debian-12`.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [ ] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [ ] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [x] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [x] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
