### PR TITLE
feat(GKE): add binary-authorization enforce sample

### DIFF
--- a/gke/standard/regional/binary-authorization/main.tf
+++ b/gke/standard/regional/binary-authorization/main.tf
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-# [START gke_standard_regional_binary-authorization-enforce]
+# [START gke_standard_regional_binauthz_enforce]
 resource "google_container_cluster" "enforce" {
   name               = "gke-standard-regional-binauthz-enforce"
   location           = "us-west1"
@@ -28,4 +28,4 @@ resource "google_container_cluster" "enforce" {
   # accidentally delete this instance by use of Terraform.
   deletion_protection = false
 }
-# [END gke_standard_regional_binary-authorization-enforce]
+# [END gke_standard_regional_binauthz_enforce]

--- a/gke/standard/regional/binary-authorization/main.tf
+++ b/gke/standard/regional/binary-authorization/main.tf
@@ -1,0 +1,31 @@
+/**
+* Copyright 2024 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+# [START gke_standard_regional_binary-authorization-enforce]
+resource "google_container_cluster" "enforce" {
+  name               = "gke-standard-regional-binauthz-enforce"
+  location           = "us-west1"
+  initial_node_count = 1
+
+  binary_authorization {
+    evaluation_mode = "PROJECT_SINGLETON_POLICY_ENFORCE"
+  }
+
+  # Set `deletion_protection` to `true` will ensure that one cannot
+  # accidentally delete this instance by use of Terraform.
+  deletion_protection = false
+}
+# [END gke_standard_regional_binary-authorization-enforce]


### PR DESCRIPTION
## Description

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): https://cloud.google.com/binary-authorization/docs/creating-cluster

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [x] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [x] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
