### PR TITLE
fix(cloud_sql): update to ssl_mode

### DIFF
--- a/cloud_sql/instance_ssl_cert/main.tf
+++ b/cloud_sql/instance_ssl_cert/main.tf
@@ -22,7 +22,7 @@ resource "google_sql_database_instance" "mysql_instance" {
   settings {
     tier = "db-f1-micro"
     ip_configuration {
-      require_ssl = "true"
+      ssl_mode = "ENCRYPTED_ONLY"
     }
   }
   # set `deletion_protection` to true, will ensure that one cannot accidentally delete this instance by
@@ -46,7 +46,7 @@ resource "google_sql_database_instance" "postgres_instance" {
   settings {
     tier = "db-custom-2-7680"
     ip_configuration {
-      require_ssl = "true"
+      ssl_mode = "ENCRYPTED_ONLY"
     }
   }
   # set `deletion_protection` to true, will ensure that one cannot accidentally delete this instance by
@@ -71,7 +71,7 @@ resource "google_sql_database_instance" "sqlserver_instance" {
   settings {
     tier = "db-custom-2-7680"
     ip_configuration {
-      require_ssl = "true"
+      ssl_mode = "ENCRYPTED_ONLY"
     }
   }
   # set `deletion_protection` to true, will ensure that one cannot accidentally delete this instance by

--- a/cloud_sql/mysql_instance_ssl_cert/main.tf
+++ b/cloud_sql/mysql_instance_ssl_cert/main.tf
@@ -25,8 +25,7 @@ resource "google_sql_database_instance" "mysql_instance" {
       # The following SSL enforcement options only allow connections encrypted with SSL/TLS and with
       # valid client certificates. Please check the API reference for other SSL enforcement options:
       # https://cloud.google.com/sql/docs/postgres/admin-api/rest/v1beta4/instances#ipconfiguration
-      require_ssl = "true"
-      ssl_mode    = "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
+      ssl_mode = "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
     }
   }
   # set `deletion_protection` to true, will ensure that one cannot accidentally delete this instance by

--- a/cloud_sql/postgres_instance_ssl_cert/main.tf
+++ b/cloud_sql/postgres_instance_ssl_cert/main.tf
@@ -25,8 +25,7 @@ resource "google_sql_database_instance" "postgres_instance" {
       # The following SSL enforcement options only allow connections encrypted with SSL/TLS and with
       # valid client certificates. Please check the API reference for other SSL enforcement options:
       # https://cloud.google.com/sql/docs/postgres/admin-api/rest/v1beta4/instances#ipconfiguration
-      require_ssl = "true"
-      ssl_mode    = "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
+      ssl_mode = "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
     }
   }
   # set `deletion_protection` to true, will ensure that one cannot accidentally delete this instance by

--- a/cloud_sql/sqlserver_instance_ssl_cert/main.tf
+++ b/cloud_sql/sqlserver_instance_ssl_cert/main.tf
@@ -23,7 +23,7 @@ resource "google_sql_database_instance" "sqlserver_instance" {
   settings {
     tier = "db-custom-2-7680"
     ip_configuration {
-      require_ssl = "true"
+      ssl_mode = "ENCRYPTED_ONLY"
     }
   }
   # set `deletion_protection` to true, will ensure that one cannot accidentally delete this instance by


### PR DESCRIPTION
## Description

Migrate from `require_ssl` to `ssl_mode` for: https://github.com/hashicorp/terraform-provider-google/releases/tag/v6.0.1 

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [ ] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [x] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [x] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
