### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ authenticates Terraform, letting you get started with less setup.
 
 1. Clone this repository:
 
-   git clone https://github.com/GoogleCloudPlatform/terraform-docs-samples.git
+   git clone [https://github.com/terraform-google-modules/terraform-docs-samples.git](https://github.com/terraform-google-modules/terraform-docs-samples.git)
 
 ## How to run a sample
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ authenticates Terraform, letting you get started with less setup.
 
 1. Clone this repository:
 
-   git clone [https://github.com/terraform-google-modules/terraform-docs-samples.git](https://github.com/terraform-google-modules/terraform-docs-samples.git)
+    `git clone https://github.com/terraform-google-modules/terraform-docs-samples`
 
 ## How to run a sample
 


### PR DESCRIPTION
Step `No.2` in the [Setup Section](https://github.com/terraform-google-modules/terraform-docs-samples/tree/main?tab=readme-ov-file#setup), update the `git clone` command to target a valid and live [terraform-docs-samples](https://github.com/terraform-google-modules/terraform-docs-samples.git) repository:

```sh
git clone https://github.com/terraform-google-modules/terraform-docs-samples.git
```

The existing instruction for the cloning of the `terraform-docs-samples`:

```sh
git clone https://github.com/GoogleCloudPlatform/terraform-docs-samples.git
```

is targeting an inadmissible repository.
