### PR TITLE
docs: Update main.tf to support how-to guide in Eventarc docset

### DIFF
--- a/eventarc/workflows/main.tf
+++ b/eventarc/workflows/main.tf
@@ -96,9 +96,9 @@ resource "google_project_iam_member" "pubsubpublisher" {
 # [START eventarc_workflows_deploy]
 # Create a workflow
 resource "google_workflows_workflow" "default" {
-  name        = "storage-workflow-tf"
-  region      = "us-central1"
-  description = "Workflow that returns information about storage events"
+  name            = "storage-workflow-tf"
+  region          = "us-central1"
+  description     = "Workflow that returns information about storage events"
   service_account = google_service_account.eventarc.email
 
   deletion_protection = false # set to "true" in production

--- a/eventarc/workflows/main.tf
+++ b/eventarc/workflows/main.tf
@@ -16,15 +16,15 @@
 
 # [START eventarc_workflows_parent_tag]
 # [START eventarc_terraform_workflows_enableapis]
-# Enable Eventarc API
-resource "google_project_service" "eventarc" {
-  service            = "eventarc.googleapis.com"
-  disable_on_destroy = false
-}
-
 # Enable Workflows API
 resource "google_project_service" "workflows" {
   service            = "workflows.googleapis.com"
+  disable_on_destroy = false
+}
+
+# Enable Eventarc API
+resource "google_project_service" "eventarc" {
+  service            = "eventarc.googleapis.com"
   disable_on_destroy = false
 }
 
@@ -45,7 +45,7 @@ resource "google_service_account" "eventarc" {
   display_name = "Eventarc Workflows Service Account"
 }
 
-# Grant permission to invoke workflows
+# Grant permission to invoke Workflows
 resource "google_project_iam_member" "workflowsinvoker" {
   project = data.google_project.project.id
   role    = "roles/workflows.invoker"
@@ -56,6 +56,13 @@ resource "google_project_iam_member" "workflowsinvoker" {
 resource "google_project_iam_member" "eventreceiver" {
   project = data.google_project.project.id
   role    = "roles/eventarc.eventReceiver"
+  member  = "serviceAccount:${google_service_account.eventarc.email}"
+}
+
+# Grant permission to write logs
+resource "google_project_iam_member" "logwriter" {
+  project = data.google_project.project.id
+  role    = "roles/logging.logWriter"
   member  = "serviceAccount:${google_service_account.eventarc.email}"
 }
 # [END eventarc_workflows_create_serviceaccount]
@@ -92,6 +99,7 @@ resource "google_workflows_workflow" "default" {
   name        = "storage-workflow-tf"
   region      = "us-central1"
   description = "Workflow that returns information about storage events"
+  service_account = google_service_account.eventarc.email
 
   deletion_protection = false # set to "true" in production
 


### PR DESCRIPTION
Per b/355941670

Associate workflow w/dedicated SA that can write logs

## Description

Fixes #<ISSUE-NUMBER>

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [ x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x ] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x ] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x ] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x ] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [ x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): https://cloud.devsite.corp.google.com/eventarc/docs/creating-triggers-terraform

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
