### PR TITLE
feat(gke): add mesh samples

### DIFF
--- a/gke/autopilot/mesh/main.tf
+++ b/gke/autopilot/mesh/main.tf
@@ -1,0 +1,63 @@
+/**
+* Copyright 2025 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+# [START gke_autopilot_mesh]
+data "google_project" "default" {}
+
+resource "google_project_service" "default" {
+  for_each = toset([
+    "meshconfig.googleapis.com"
+  ])
+
+  service            = each.value
+  disable_on_destroy = false
+}
+
+resource "google_container_cluster" "default" {
+  name     = "gke-autopilot-mesh"
+  location = "us-central1"
+
+  enable_autopilot = true
+
+  fleet {
+    project = data.google_project.default.project_id
+  }
+
+  # Set `deletion_protection` to `true` will ensure that one cannot
+  # accidentally delete this instance by use of Terraform.
+  deletion_protection = false
+}
+
+resource "google_gke_hub_feature" "default" {
+  name     = "servicemesh"
+  location = "global"
+
+  depends_on = [google_project_service.default]
+}
+
+
+resource "google_gke_hub_feature_membership" "default" {
+  location = "global"
+
+  feature             = google_gke_hub_feature.default.name
+  membership          = google_container_cluster.default.fleet[0].membership_id
+  membership_location = google_container_cluster.default.fleet[0].membership_location
+
+  mesh {
+    management = "MANAGEMENT_AUTOMATIC"
+  }
+}
+# [END gke_autopilot_mesh]

--- a/gke/enterprise/mesh/main.tf
+++ b/gke/enterprise/mesh/main.tf
@@ -1,0 +1,39 @@
+/**
+* Copyright 2025 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+# [START gke_enterprise_mesh]
+resource "google_project_service" "default" {
+  for_each = toset([
+    "meshconfig.googleapis.com"
+  ])
+
+  service            = each.value
+  disable_on_destroy = false
+}
+
+resource "google_gke_hub_feature" "default" {
+  name     = "servicemesh"
+  location = "global"
+
+  fleet_default_member_config {
+    mesh {
+      management = "MANAGEMENT_AUTOMATIC"
+    }
+  }
+
+  depends_on = [google_project_service.default]
+}
+# [END gke_enterprise_mesh]


### PR DESCRIPTION
## Description

Adds cluster and fleet (enterprise) mesh samples

b/387532163

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): https://cloud.google.com/service-mesh/docs/onboarding/provision-control-plane

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [x] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [x] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
