### PR TITLE
feat(gke): add config_sync (fleet) example

### DIFF
--- a/gke/enterprise/config_sync/git/main.tf
+++ b/gke/enterprise/config_sync/git/main.tf
@@ -1,0 +1,55 @@
+/**
+* Copyright 2024-2025 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+# [START gke_enterprise_config_sync_git]
+data "google_project" "default" {}
+
+resource "google_container_cluster" "default" {
+  name     = "gke-autopilot-basic"
+  location = "us-central1"
+
+  fleet {
+    project = data.google_project.default.project_id
+  }
+
+  enable_autopilot = true
+
+  # Set `deletion_protection` to `true` will ensure that one cannot
+  # accidentally delete this instance by use of Terraform.
+  deletion_protection = false
+}
+
+resource "google_gke_hub_feature" "default" {
+  name     = "configmanagement"
+  location = "global"
+
+  fleet_default_member_config {
+    configmanagement {
+      config_sync {
+        # The field `enabled` was introduced in Terraform version 5.41.0, and
+        # needs to be set to `true` explicitly to install Config Sync.
+        enabled = true
+        git {
+          sync_repo   = "REPO"
+          sync_branch = "BRANCH"
+          policy_dir  = "DIRECTORY"
+          secret_type = "SECRET"
+        }
+      }
+    }
+  }
+}
+# [END gke_enterprise_config_sync_git]

--- a/gke/enterprise/config_sync/git/main.tf
+++ b/gke/enterprise/config_sync/git/main.tf
@@ -15,23 +15,6 @@
 */
 
 # [START gke_enterprise_config_sync_git]
-data "google_project" "default" {}
-
-resource "google_container_cluster" "default" {
-  name     = "gke-autopilot-basic"
-  location = "us-central1"
-
-  fleet {
-    project = data.google_project.default.project_id
-  }
-
-  enable_autopilot = true
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
-}
-
 resource "google_gke_hub_feature" "default" {
   name     = "configmanagement"
   location = "global"

--- a/gke/enterprise/config_sync/git/test.yaml
+++ b/gke/enterprise/config_sync/git/test.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2024-2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gke/enterprise/config_sync/git/test.yaml
+++ b/gke/enterprise/config_sync/git/test.yaml
@@ -1,0 +1,21 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The kubernetes_manifest resource can only be used with pre-existing clusters.
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintTest
+metadata:
+  name: config_sync_git
+spec:
+  skip: true

--- a/gke/enterprise/config_sync/oci/main.tf
+++ b/gke/enterprise/config_sync/oci/main.tf
@@ -1,0 +1,54 @@
+/**
+* Copyright 2024-2025 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+# [START gke_enterprise_config_sync_oci]
+data "google_project" "default" {}
+
+resource "google_container_cluster" "default" {
+  name     = "gke-autopilot-basic"
+  location = "us-central1"
+
+  fleet {
+    project = data.google_project.default.project_id
+  }
+
+  enable_autopilot = true
+
+  # Set `deletion_protection` to `true` will ensure that one cannot
+  # accidentally delete this instance by use of Terraform.
+  deletion_protection = false
+}
+
+resource "google_gke_hub_feature" "configmanagement_feature_member" {
+  name     = "configmanagement"
+  location = "global"
+
+  fleet_default_member_config {
+    configmanagement {
+      config_sync {
+        # The field `enabled` was introduced in Terraform version 5.41.0, and
+        # needs to be set to `true` explicitly to install Config Sync.
+        enabled = true
+        oci {
+          sync_repo   = "REPO"
+          policy_dir  = "DIRECTORY"
+          secret_type = "SECRET"
+        }
+      }
+    }
+  }
+}
+# [END gke_enterprise_config_sync_oci]

--- a/gke/enterprise/config_sync/oci/main.tf
+++ b/gke/enterprise/config_sync/oci/main.tf
@@ -15,23 +15,6 @@
 */
 
 # [START gke_enterprise_config_sync_oci]
-data "google_project" "default" {}
-
-resource "google_container_cluster" "default" {
-  name     = "gke-autopilot-basic"
-  location = "us-central1"
-
-  fleet {
-    project = data.google_project.default.project_id
-  }
-
-  enable_autopilot = true
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
-}
-
 resource "google_gke_hub_feature" "configmanagement_feature_member" {
   name     = "configmanagement"
   location = "global"

--- a/gke/enterprise/config_sync/oci/test.yaml
+++ b/gke/enterprise/config_sync/oci/test.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2024-2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gke/enterprise/config_sync/oci/test.yaml
+++ b/gke/enterprise/config_sync/oci/test.yaml
@@ -1,0 +1,21 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The kubernetes_manifest resource can only be used with pre-existing clusters.
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintTest
+metadata:
+  name: config_sync_oci
+spec:
+  skip: true


### PR DESCRIPTION
## Description

b/388321419

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [ ] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/how-to/installing-config-sync

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [x] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [x] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
