### PR TITLE
feat(networksecurity): add tags for all resources in Mirroring docs

### DIFF
--- a/network_security/mirroring/basic/consumer/main.tf
+++ b/network_security/mirroring/basic/consumer/main.tf
@@ -15,32 +15,41 @@
 */
 
 # [START networksecurity_mirroring_basic_consumer]
+# [START networksecurity_mirroring_cons_new_producer_network_tf]
 resource "google_compute_network" "producer_network" {
   provider                = google-beta
   name                    = "producer-network"
   auto_create_subnetworks = false
 }
+# [END networksecurity_mirroring_cons_new_producer_network_tf]
 
+# [START networksecurity_mirroring_cons_new_consumer_network_tf]
 resource "google_compute_network" "consumer_network" {
   provider                = google-beta
   name                    = "consumer-network"
   auto_create_subnetworks = false
 }
+# [END networksecurity_mirroring_cons_new_consumer_network_tf]
 
+# [START networksecurity_mirroring_cons_new_deployment_group_tf]
 resource "google_network_security_mirroring_deployment_group" "default" {
   provider                      = google-beta
   mirroring_deployment_group_id = "mirroring-deployment-group"
   location                      = "global"
   network                       = google_compute_network.producer_network.id
 }
+# [END networksecurity_mirroring_cons_new_deployment_group_tf]
 
+# [START networksecurity_mirroring_cons_new_endpoint_group_tf]
 resource "google_network_security_mirroring_endpoint_group" "default" {
   provider                    = google-beta
   mirroring_endpoint_group_id = "mirroring-endpoint-group"
   location                    = "global"
   mirroring_deployment_group  = google_network_security_mirroring_deployment_group.default.id
 }
+# [END networksecurity_mirroring_cons_new_endpoint_group_tf]
 
+# [START networksecurity_mirroring_cons_new_endpoint_group_association_tf]
 resource "google_network_security_mirroring_endpoint_group_association" "default" {
   provider                                = google-beta
   mirroring_endpoint_group_association_id = "mirroring-endpoint-group-association"
@@ -48,4 +57,5 @@ resource "google_network_security_mirroring_endpoint_group_association" "default
   network                                 = google_compute_network.consumer_network.id
   mirroring_endpoint_group                = google_network_security_mirroring_endpoint_group.default.id
 }
+# [END networksecurity_mirroring_cons_new_endpoint_group_association_tf]
 # [END networksecurity_mirroring_basic_consumer]

--- a/network_security/mirroring/basic/consumer/main.tf
+++ b/network_security/mirroring/basic/consumer/main.tf
@@ -15,41 +15,41 @@
 */
 
 # [START networksecurity_mirroring_basic_consumer]
-# [START networksecurity_mirroring_cons_new_producer_network_tf]
+# [START networksecurity_mirroring_create_producer_network_tf]
 resource "google_compute_network" "producer_network" {
   provider                = google-beta
   name                    = "producer-network"
   auto_create_subnetworks = false
 }
-# [END networksecurity_mirroring_cons_new_producer_network_tf]
+# [END networksecurity_mirroring_create_producer_network_tf]
 
-# [START networksecurity_mirroring_cons_new_consumer_network_tf]
+# [START networksecurity_mirroring_create_consumer_network_tf]
 resource "google_compute_network" "consumer_network" {
   provider                = google-beta
   name                    = "consumer-network"
   auto_create_subnetworks = false
 }
-# [END networksecurity_mirroring_cons_new_consumer_network_tf]
+# [END networksecurity_mirroring_create_consumer_network_tf]
 
-# [START networksecurity_mirroring_cons_new_deployment_group_tf]
+# [START networksecurity_mirroring_create_producer_deployment_group_tf]
 resource "google_network_security_mirroring_deployment_group" "default" {
   provider                      = google-beta
   mirroring_deployment_group_id = "mirroring-deployment-group"
   location                      = "global"
   network                       = google_compute_network.producer_network.id
 }
-# [END networksecurity_mirroring_cons_new_deployment_group_tf]
+# [END networksecurity_mirroring_create_producer_deployment_group_tf]
 
-# [START networksecurity_mirroring_cons_new_endpoint_group_tf]
+# [START networksecurity_mirroring_create_endpoint_group_tf]
 resource "google_network_security_mirroring_endpoint_group" "default" {
   provider                    = google-beta
   mirroring_endpoint_group_id = "mirroring-endpoint-group"
   location                    = "global"
   mirroring_deployment_group  = google_network_security_mirroring_deployment_group.default.id
 }
-# [END networksecurity_mirroring_cons_new_endpoint_group_tf]
+# [END networksecurity_mirroring_create_endpoint_group_tf]
 
-# [START networksecurity_mirroring_cons_new_endpoint_group_association_tf]
+# [START networksecurity_mirroring_create_endpoint_group_association_tf]
 resource "google_network_security_mirroring_endpoint_group_association" "default" {
   provider                                = google-beta
   mirroring_endpoint_group_association_id = "mirroring-endpoint-group-association"
@@ -57,5 +57,5 @@ resource "google_network_security_mirroring_endpoint_group_association" "default
   network                                 = google_compute_network.consumer_network.id
   mirroring_endpoint_group                = google_network_security_mirroring_endpoint_group.default.id
 }
-# [END networksecurity_mirroring_cons_new_endpoint_group_association_tf]
+# [END networksecurity_mirroring_create_endpoint_group_association_tf]
 # [END networksecurity_mirroring_basic_consumer]

--- a/network_security/mirroring/basic/producer/main.tf
+++ b/network_security/mirroring/basic/producer/main.tf
@@ -15,15 +15,15 @@
 */
 
 # [START networksecurity_mirroring_basic_producer]
-# [START networksecurity_mirroring_prod_new_network_tf]
+# [START networksecurity_mirroring_create_network_tf]
 resource "google_compute_network" "default" {
   provider                = google-beta
   name                    = "producer-network"
   auto_create_subnetworks = false
 }
-# [END networksecurity_mirroring_prod_new_network_tf]
+# [END networksecurity_mirroring_create_network_tf]
 
-# [START networksecurity_mirroring_prod_new_subnetwork_tf]
+# [START networksecurity_mirroring_create_subnetwork_tf]
 resource "google_compute_subnetwork" "default" {
   provider      = google-beta
   name          = "producer-subnet"
@@ -31,9 +31,9 @@ resource "google_compute_subnetwork" "default" {
   ip_cidr_range = "10.1.0.0/16"
   network       = google_compute_network.default.name
 }
-# [END networksecurity_mirroring_prod_new_subnetwork_tf]
+# [END networksecurity_mirroring_create_subnetwork_tf]
 
-# [START networksecurity_mirroring_prod_new_health_check_tf]
+# [START networksecurity_mirroring_create_health_check_tf]
 resource "google_compute_region_health_check" "default" {
   provider = google-beta
   name     = "deploymnet-hc"
@@ -42,9 +42,9 @@ resource "google_compute_region_health_check" "default" {
     port = 80
   }
 }
-# [END networksecurity_mirroring_prod_new_health_check_tf]
+# [END networksecurity_mirroring_create_health_check_tf]
 
-# [START networksecurity_mirroring_prod_new_backend_service_tf]
+# [START networksecurity_mirroring_create_backend_service_tf]
 resource "google_compute_region_backend_service" "default" {
   provider              = google-beta
   name                  = "deployment-svc"
@@ -53,9 +53,9 @@ resource "google_compute_region_backend_service" "default" {
   protocol              = "UDP"
   load_balancing_scheme = "INTERNAL"
 }
-# [END networksecurity_mirroring_prod_new_backend_service_tf]
+# [END networksecurity_mirroring_create_backend_service_tf]
 
-# [START networksecurity_mirroring_prod_new_forwarding_rule_tf]
+# [START networksecurity_mirroring_create_forwarding_rule_tf]
 resource "google_compute_forwarding_rule" "default" {
   provider               = google-beta
   name                   = "deployment-fr"
@@ -68,18 +68,18 @@ resource "google_compute_forwarding_rule" "default" {
   ip_protocol            = "UDP"
   is_mirroring_collector = true
 }
-# [END networksecurity_mirroring_prod_new_forwarding_rule_tf]
+# [END networksecurity_mirroring_create_forwarding_rule_tf]
 
-# [START networksecurity_mirroring_prod_new_deployment_group_tf]
+# [START networksecurity_mirroring_create_deployment_group_tf]
 resource "google_network_security_mirroring_deployment_group" "default" {
   provider                      = google-beta
   mirroring_deployment_group_id = "mirroring-deployment-group"
   location                      = "global"
   network                       = google_compute_network.default.id
 }
-# [END networksecurity_mirroring_prod_new_deployment_group_tf]
+# [END networksecurity_mirroring_create_deployment_group_tf]
 
-# [START networksecurity_mirroring_prod_new_deployment_tf]
+# [START networksecurity_mirroring_create_deployment_tf]
 resource "google_network_security_mirroring_deployment" "default" {
   provider                   = google-beta
   mirroring_deployment_id    = "mirroring-deployment"
@@ -87,5 +87,5 @@ resource "google_network_security_mirroring_deployment" "default" {
   forwarding_rule            = google_compute_forwarding_rule.default.id
   mirroring_deployment_group = google_network_security_mirroring_deployment_group.default.id
 }
-# [END networksecurity_mirroring_prod_new_deployment_tf]
+# [END networksecurity_mirroring_create_deployment_tf]
 # [END networksecurity_mirroring_basic_producer]

--- a/network_security/mirroring/basic/producer/main.tf
+++ b/network_security/mirroring/basic/producer/main.tf
@@ -15,12 +15,15 @@
 */
 
 # [START networksecurity_mirroring_basic_producer]
+# [START networksecurity_mirroring_prod_new_network_tf]
 resource "google_compute_network" "default" {
   provider                = google-beta
   name                    = "producer-network"
   auto_create_subnetworks = false
 }
+# [END networksecurity_mirroring_prod_new_network_tf]
 
+# [START networksecurity_mirroring_prod_new_subnetwork_tf]
 resource "google_compute_subnetwork" "default" {
   provider      = google-beta
   name          = "producer-subnet"
@@ -28,7 +31,9 @@ resource "google_compute_subnetwork" "default" {
   ip_cidr_range = "10.1.0.0/16"
   network       = google_compute_network.default.name
 }
+# [END networksecurity_mirroring_prod_new_subnetwork_tf]
 
+# [START networksecurity_mirroring_prod_new_health_check_tf]
 resource "google_compute_region_health_check" "default" {
   provider = google-beta
   name     = "deploymnet-hc"
@@ -37,7 +42,9 @@ resource "google_compute_region_health_check" "default" {
     port = 80
   }
 }
+# [END networksecurity_mirroring_prod_new_health_check_tf]
 
+# [START networksecurity_mirroring_prod_new_backend_service_tf]
 resource "google_compute_region_backend_service" "default" {
   provider              = google-beta
   name                  = "deployment-svc"
@@ -46,7 +53,9 @@ resource "google_compute_region_backend_service" "default" {
   protocol              = "UDP"
   load_balancing_scheme = "INTERNAL"
 }
+# [END networksecurity_mirroring_prod_new_backend_service_tf]
 
+# [START networksecurity_mirroring_prod_new_forwarding_rule_tf]
 resource "google_compute_forwarding_rule" "default" {
   provider               = google-beta
   name                   = "deployment-fr"
@@ -59,14 +68,18 @@ resource "google_compute_forwarding_rule" "default" {
   ip_protocol            = "UDP"
   is_mirroring_collector = true
 }
+# [END networksecurity_mirroring_prod_new_forwarding_rule_tf]
 
+# [START networksecurity_mirroring_prod_new_deployment_group_tf]
 resource "google_network_security_mirroring_deployment_group" "default" {
   provider                      = google-beta
   mirroring_deployment_group_id = "mirroring-deployment-group"
   location                      = "global"
   network                       = google_compute_network.default.id
 }
+# [END networksecurity_mirroring_prod_new_deployment_group_tf]
 
+# [START networksecurity_mirroring_prod_new_deployment_tf]
 resource "google_network_security_mirroring_deployment" "default" {
   provider                   = google-beta
   mirroring_deployment_id    = "mirroring-deployment"
@@ -74,4 +87,5 @@ resource "google_network_security_mirroring_deployment" "default" {
   forwarding_rule            = google_compute_forwarding_rule.default.id
   mirroring_deployment_group = google_network_security_mirroring_deployment_group.default.id
 }
+# [END networksecurity_mirroring_prod_new_deployment_tf]
 # [END networksecurity_mirroring_basic_producer]


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): https://cloud.google.com/network-security-integration/docs/out-of-band/out-of-band-integration-overview

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

Already done in a separate PR.

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)

Already done in a separate PR.
