### PR TITLE
feat: pre configure networksecurity/intercept samples

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,6 +17,7 @@
 /looker/                      @terraform-google-modules/cloud-looker-docs @terraform-google-modules/terraform-samples-reviewers
 /media_cdn/                   @terraform-google-modules/dee-infra @terraform-google-modules/terraform-samples-reviewers
 /network_connectivity/        @terraform-google-modules/dee-infra @terraform-google-modules/terraform-samples-reviewers
+/network_security/intercept/  @terraform-google-modules/pm2-team @terraform-google-modules/terraform-samples-reviewers
 /network_security/mirroring/  @terraform-google-modules/pm2-team @terraform-google-modules/terraform-samples-reviewers
 /privateca/                   @terraform-google-modules/dee-infra @terraform-google-modules/terraform-samples-reviewers
 /storage/                     @terraform-google-modules/cloud-storage-dpe @terraform-google-modules/terraform-samples-reviewers


### PR DESCRIPTION
## Description

As a prerequisite for adding doc samples under `networksecurity/intercept`, setting the `pm2-team` group as owners.
The members of this team are the owners for Network Security Integration product which includes both intercept and mirroring.

For reference, this is the PR that added mirroring: https://github.com/terraform-google-modules/terraform-docs-samples/pull/806

## Checklist

**Readiness**

- [X] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

