### PR TITLE
docs: Add CMEK for Eventarc

### DIFF
--- a/eventarc/use_cmek/main.tf
+++ b/eventarc/use_cmek/main.tf
@@ -64,7 +64,7 @@ resource "google_kms_crypto_key" "default" {
 resource "google_kms_crypto_key_iam_member" "default" {
   crypto_key_id = google_kms_crypto_key.default.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = google_project_service_identity.eventarc_sa.member
+  member        = "serviceAccount:${google_project_service_identity.eventarc_sa.email}"
 }
 # [END eventarc_terraform_cmek_role]
 

--- a/eventarc/use_cmek/main.tf
+++ b/eventarc/use_cmek/main.tf
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# [START eventarc_terraform_cmek_apis]
+# Enable Cloud KMS API
+resource "google_project_service" "cloudkms" {
+  service            = "cloudkms.googleapis.com"
+  disable_on_destroy = false
+}
+
+# Enable Eventarc API
+resource "google_project_service" "eventarc" {
+  service            = "eventarc.googleapis.com"
+  disable_on_destroy = false
+}
+# [END eventarc_terraform_cmek_apis]
+
+# Used to retrieve project information later
+data "google_project" "default" {
+}
+
+# [START eventarc_terraform_cmek_key]
+resource "random_id" "default" {
+  byte_length = 8
+}
+
+# Create a Cloud KMS key ring
+resource "google_kms_key_ring" "default" {
+  name     = "${random_id.default.hex}-example-keyring"
+  location = "us-central1"
+}
+
+# Create a Cloud KMS key
+resource "google_kms_crypto_key" "default" {
+  name            = "example-key"
+  key_ring        = google_kms_key_ring.default.id
+  rotation_period = "7776000s"
+}
+# [END eventarc_terraform_cmek_key]
+
+# [START eventarc_terraform_cmek_service_agent]
+# Grant service account access to Cloud KMS key
+resource "google_kms_crypto_key_iam_member" "default" {
+  crypto_key_id = google_kms_crypto_key.default.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.default.number}@gcp-sa-eventarc.iam.gserviceaccount.com"
+}
+# [END eventarc_terraform_cmek_service_agent]
+
+# [START eventarc_terraform_cmek_google_channel]
+# Specify a CMEK key for the `GoogleChannelConfig` resource
+resource "google_eventarc_google_channel_config" "default" {
+  location        = "us-central1"
+  name            = "googleChannelConfig"
+  crypto_key_name = google_kms_crypto_key.default.id
+  depends_on      = [google_kms_crypto_key_iam_member.default]
+}
+# [END eventarc_terraform_cmek_google_channel]


### PR DESCRIPTION


## Description

Fixes b/404495162 
Enable CMEK support for Eventarc through Terraform

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [ x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [ x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x ] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x ] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [ x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x ] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [ x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): https://cloud.google.com/eventarc/docs/use-cmek

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
