### PR TITLE
fix: unset min_master_version (outdated for all channels except EXTENDED)

### DIFF
--- a/gke/standard/zonal/secondary-boot-disk/main.tf
+++ b/gke/standard/zonal/secondary-boot-disk/main.tf
@@ -19,8 +19,11 @@ resource "google_container_cluster" "default" {
   name               = "default"
   location           = "us-central1-a"
   initial_node_count = 1
-  # Set `min_master_version` because secondary_boot_disks require GKE 1.28.3-gke.106700 or later.
-  min_master_version = "1.28"
+
+  # secondary_boot_disks require GKE 1.28.3-gke.106700 or later, which should
+  # be true for all release channels apart from EXTENDED.
+  # If required, Use `release_channel = "EXTENDED"` and set `min_master_version`.
+
   # Setting `deletion_protection` to `true` would prevent
   # accidental deletion of this instance using Terraform.
   deletion_protection = false


### PR DESCRIPTION
## Description

Addresses periodic failures (https://github.com/terraform-google-modules/terraform-docs-samples/issues/781#issuecomment-2764648219) `Error 400: No valid versions with the prefix "1.28" found.`

Removes `min_master_version`

The default version should be >1.28 for all release channels apart from Extended ([source](https://cloud.google.com/kubernetes-engine/docs/release-notes)).  Logged upstream  https://github.com/hashicorp/terraform-provider-google/issues/22167

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved
