### PR TITLE
feat(networksecurity): Remove google-beta provider from mirroring samples

### DIFF
--- a/network_security/mirroring/basic/consumer/main.tf
+++ b/network_security/mirroring/basic/consumer/main.tf
@@ -17,7 +17,6 @@
 # [START networksecurity_mirroring_basic_consumer]
 # [START networksecurity_mirroring_create_producer_network_tf]
 resource "google_compute_network" "producer_network" {
-  provider                = google-beta
   name                    = "producer-network"
   auto_create_subnetworks = false
 }
@@ -25,7 +24,6 @@ resource "google_compute_network" "producer_network" {
 
 # [START networksecurity_mirroring_create_consumer_network_tf]
 resource "google_compute_network" "consumer_network" {
-  provider                = google-beta
   name                    = "consumer-network"
   auto_create_subnetworks = false
 }
@@ -33,7 +31,6 @@ resource "google_compute_network" "consumer_network" {
 
 # [START networksecurity_mirroring_create_producer_deployment_group_tf]
 resource "google_network_security_mirroring_deployment_group" "default" {
-  provider                      = google-beta
   mirroring_deployment_group_id = "mirroring-deployment-group"
   location                      = "global"
   network                       = google_compute_network.producer_network.id
@@ -42,7 +39,6 @@ resource "google_network_security_mirroring_deployment_group" "default" {
 
 # [START networksecurity_mirroring_create_endpoint_group_tf]
 resource "google_network_security_mirroring_endpoint_group" "default" {
-  provider                    = google-beta
   mirroring_endpoint_group_id = "mirroring-endpoint-group"
   location                    = "global"
   mirroring_deployment_group  = google_network_security_mirroring_deployment_group.default.id
@@ -51,7 +47,6 @@ resource "google_network_security_mirroring_endpoint_group" "default" {
 
 # [START networksecurity_mirroring_create_endpoint_group_association_tf]
 resource "google_network_security_mirroring_endpoint_group_association" "default" {
-  provider                                = google-beta
   mirroring_endpoint_group_association_id = "mirroring-endpoint-group-association"
   location                                = "global"
   network                                 = google_compute_network.consumer_network.id

--- a/network_security/mirroring/basic/producer/main.tf
+++ b/network_security/mirroring/basic/producer/main.tf
@@ -17,7 +17,6 @@
 # [START networksecurity_mirroring_basic_producer]
 # [START networksecurity_mirroring_create_network_tf]
 resource "google_compute_network" "default" {
-  provider                = google-beta
   name                    = "producer-network"
   auto_create_subnetworks = false
 }
@@ -25,7 +24,6 @@ resource "google_compute_network" "default" {
 
 # [START networksecurity_mirroring_create_subnetwork_tf]
 resource "google_compute_subnetwork" "default" {
-  provider      = google-beta
   name          = "producer-subnet"
   region        = "us-central1"
   ip_cidr_range = "10.1.0.0/16"
@@ -35,9 +33,8 @@ resource "google_compute_subnetwork" "default" {
 
 # [START networksecurity_mirroring_create_health_check_tf]
 resource "google_compute_region_health_check" "default" {
-  provider = google-beta
-  name     = "deploymnet-hc"
-  region   = "us-central1"
+  name   = "deploymnet-hc"
+  region = "us-central1"
   http_health_check {
     port = 80
   }
@@ -46,7 +43,6 @@ resource "google_compute_region_health_check" "default" {
 
 # [START networksecurity_mirroring_create_backend_service_tf]
 resource "google_compute_region_backend_service" "default" {
-  provider              = google-beta
   name                  = "deployment-svc"
   region                = "us-central1"
   health_checks         = [google_compute_region_health_check.default.id]
@@ -57,7 +53,6 @@ resource "google_compute_region_backend_service" "default" {
 
 # [START networksecurity_mirroring_create_forwarding_rule_tf]
 resource "google_compute_forwarding_rule" "default" {
-  provider               = google-beta
   name                   = "deployment-fr"
   region                 = "us-central1"
   network                = google_compute_network.default.name
@@ -72,7 +67,6 @@ resource "google_compute_forwarding_rule" "default" {
 
 # [START networksecurity_mirroring_create_deployment_group_tf]
 resource "google_network_security_mirroring_deployment_group" "default" {
-  provider                      = google-beta
   mirroring_deployment_group_id = "mirroring-deployment-group"
   location                      = "global"
   network                       = google_compute_network.default.id
@@ -81,7 +75,6 @@ resource "google_network_security_mirroring_deployment_group" "default" {
 
 # [START networksecurity_mirroring_create_deployment_tf]
 resource "google_network_security_mirroring_deployment" "default" {
-  provider                   = google-beta
   mirroring_deployment_id    = "mirroring-deployment"
   location                   = "us-central1-a"
   forwarding_rule            = google_compute_forwarding_rule.default.id


### PR DESCRIPTION
## Description

Use the google provider (implicitly the default) instead of the google-beta provider for mirroring samples.
This will fix our docs that currently show the google-beta provider in their terraform samples.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [x] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [x] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
