### PR TITLE
feat(cloud_sql): add disabling psc on PSA+PSC instances examples

### DIFF
--- a/cloud_sql/mysql_instance_psa_psc/main.tf
+++ b/cloud_sql/mysql_instance_psa_psc/main.tf
@@ -91,3 +91,28 @@ resource "google_compute_forwarding_rule" "default" {
 
 # [END cloud_sql_mysql_instance_psa_psc_parent_tag]
 
+// Configure a Cloud SQL MySQL instance with Private Service Connect disabled.
+# [START cloud_sql_mysql_instance_disable_psc_instance]
+resource "google_sql_database_instance" "disable_psc_example" {
+  name             = "mysql-disable-psc-example"
+  region           = "us-central1"
+  database_version = "MYSQL_8_0"
+
+  depends_on = [google_service_networking_connection.default]
+
+  settings {
+    tier = "db-f1-micro"
+    ip_configuration {
+      psc_config {
+        psc_enabled               = false
+        allowed_consumer_projects = [] # clear consumer projects
+      }
+      ipv4_enabled    = false
+      private_network = google_compute_network.peering_network.id
+    }
+  }
+  # set `deletion_protection` to true, will ensure that one cannot accidentally delete this instance by
+  # use of Terraform whereas `deletion_protection_enabled` flag protects this instance at the GCP level.
+  deletion_protection = false
+}
+# [END cloud_sql_mysql_instance_disable_psc_instance]

--- a/cloud_sql/postgres_instance_psa_psc/main.tf
+++ b/cloud_sql/postgres_instance_psa_psc/main.tf
@@ -94,3 +94,33 @@ resource "google_compute_forwarding_rule" "default" {
 }
 
 # [END cloud_sql_postgres_instance_psa_psc_parent_tag]
+
+// Configure a Cloud SQL Postgres instance with Private Service Connect disabled.
+# [START cloud_sql_postgres_instance_disable_psc_instance]
+resource "google_sql_database_instance" "disable_psc_example" {
+  name             = "postgres-disable-psc-example"
+  region           = "us-central1"
+  database_version = "POSTGRES_17"
+
+  depends_on = [google_service_networking_connection.default]
+
+  settings {
+    tier              = "db-custom-2-7680"
+    availability_type = "REGIONAL"
+    backup_configuration {
+      enabled = true
+    }
+    ip_configuration {
+      psc_config {
+        psc_enabled               = false
+        allowed_consumer_projects = [] # clear consumer projects
+      }
+      ipv4_enabled    = false
+      private_network = google_compute_network.peering_network.id
+    }
+  }
+  # set `deletion_protection` to true, will ensure that one cannot accidentally delete this instance by
+  # use of Terraform whereas `deletion_protection_enabled` flag protects this instance at the GCP level.
+  deletion_protection = false # Set to "true" to prevent destruction of the resource
+}
+# [END cloud_sql_postgres_instance_disable_psc_instance]

--- a/cloud_sql/sqlserver_instance_psa_psc/main.tf
+++ b/cloud_sql/sqlserver_instance_psa_psc/main.tf
@@ -92,3 +92,29 @@ resource "google_compute_forwarding_rule" "default" {
 
 # [END cloud_sql_sqlserver_instance_psa_psc_parent_tag]
 
+// Configure a Cloud SQL SQL server instance with Private Service Connect disabled.
+# [START cloud_sql_sqlserver_instance_disable_psc_instance]
+resource "google_sql_database_instance" "disable_psc_example" {
+  name             = "sqlserver-disable-psc-example"
+  region           = "us-central1"
+  database_version = "SQLSERVER_2019_STANDARD"
+  root_password    = "INSERT-PASSWORD-HERE"
+
+  depends_on = [google_service_networking_connection.default]
+
+  settings {
+    tier = "db-custom-2-7680"
+    ip_configuration {
+      psc_config {
+        psc_enabled               = false
+        allowed_consumer_projects = [] # clear consumer projects
+      }
+      ipv4_enabled    = false
+      private_network = google_compute_network.peering_network.id
+    }
+  }
+  # set `deletion_protection` to true, will ensure that one cannot accidentally delete this instance by
+  # use of Terraform whereas `deletion_protection_enabled` flag protects this instance at the GCP level.
+  deletion_protection = false
+}
+# [END cloud_sql_sqlserver_instance_disable_psc_instance]


### PR DESCRIPTION
## Description

Fixes #383556956

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): https://cloud.google.com/sql/docs/mysql/configure-private-services-access-and-private-service-connect#terraform


- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
