### PR TITLE
feat(networksecurity): Add samples for mirroring rule creation

### DIFF
--- a/network_security/mirroring/basic/consumer/main.tf
+++ b/network_security/mirroring/basic/consumer/main.tf
@@ -14,6 +14,19 @@
 * limitations under the License.
 */
 
+data "google_project" "default" {}
+
+# In case the project is in a folder, extract the organization ID from it.
+data "google_folder" "default" {
+  count               = data.google_project.default.folder_id != "" ? 1 : 0
+  folder              = data.google_project.default.folder_id
+  lookup_organization = true
+}
+
+data "google_organization" "default" {
+  organization = data.google_project.default.org_id != "" ? data.google_project.default.org_id : data.google_folder.default[0].organization
+}
+
 # [START networksecurity_mirroring_basic_consumer]
 # [START networksecurity_mirroring_create_producer_network_tf]
 resource "google_compute_network" "producer_network" {
@@ -28,6 +41,15 @@ resource "google_compute_network" "consumer_network" {
   auto_create_subnetworks = false
 }
 # [END networksecurity_mirroring_create_consumer_network_tf]
+
+# [START networksecurity_mirroring_create_consumer_subnetwork_tf]
+resource "google_compute_subnetwork" "consumer_subnet" {
+  name          = "consumer-subnet"
+  region        = "us-central1"
+  ip_cidr_range = "10.10.0.0/16"
+  network       = google_compute_network.consumer_network.name
+}
+# [END networksecurity_mirroring_create_consumer_subnetwork_tf]
 
 # [START networksecurity_mirroring_create_producer_deployment_group_tf]
 resource "google_network_security_mirroring_deployment_group" "default" {
@@ -53,4 +75,59 @@ resource "google_network_security_mirroring_endpoint_group_association" "default
   mirroring_endpoint_group                = google_network_security_mirroring_endpoint_group.default.id
 }
 # [END networksecurity_mirroring_create_endpoint_group_association_tf]
+
+# [START networksecurity_mirroring_create_security_profile_tf]
+resource "google_network_security_security_profile" "default" {
+  name     = "security-profile"
+  type     = "CUSTOM_MIRRORING"
+  parent   = "organizations/${data.google_organization.default.org_id}"
+  location = "global"
+
+  custom_mirroring_profile {
+    mirroring_endpoint_group = google_network_security_mirroring_endpoint_group.default.id
+  }
+}
+# [END networksecurity_mirroring_create_security_profile_tf]
+
+# [START networksecurity_mirroring_create_security_profile_group_tf]
+resource "google_network_security_security_profile_group" "default" {
+  name                     = "security-profile-group"
+  parent                   = "organizations/${data.google_organization.default.org_id}"
+  location                 = "global"
+  custom_mirroring_profile = google_network_security_security_profile.default.id
+}
+# [END networksecurity_mirroring_create_security_profile_group_tf]
+
+# [START networksecurity_mirroring_create_firewall_policy_tf]
+resource "google_compute_network_firewall_policy" "default" {
+  name = "firewall-policy"
+}
+# [END networksecurity_mirroring_create_firewall_policy_tf]
+
+# [START networksecurity_mirroring_create_firewall_policy_rule_tf]
+resource "google_compute_network_firewall_policy_packet_mirroring_rule" "default" {
+  provider               = google-beta
+  firewall_policy        = google_compute_network_firewall_policy.default.name
+  priority               = 1000
+  action                 = "mirror"
+  direction              = "INGRESS"
+  security_profile_group = google_network_security_security_profile_group.default.id
+
+  match {
+    layer4_configs {
+      ip_protocol = "tcp"
+      ports       = ["80"]
+    }
+    src_ip_ranges = ["10.10.0.0/16"]
+  }
+}
+# [END networksecurity_mirroring_create_firewall_policy_rule_tf]
+
+# [START networksecurity_mirroring_create_firewall_policy_association_tf]
+resource "google_compute_network_firewall_policy_association" "default" {
+  name              = "firewall-policy-assoc"
+  attachment_target = google_compute_network.consumer_network.id
+  firewall_policy   = google_compute_network_firewall_policy.default.name
+}
+# [END networksecurity_mirroring_create_firewall_policy_association_tf]
 # [END networksecurity_mirroring_basic_consumer]

--- a/network_security/mirroring/basic/consumer/test.yaml
+++ b/network_security/mirroring/basic/consumer/test.yaml
@@ -1,0 +1,20 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintTest
+metadata:
+  name: network_security_mirroring_basic_consumer
+spec:
+  skip: true


### PR DESCRIPTION
## Description

Adding samples for Security Profile, Security Profile Group and Global Firewall Policy, to showcase how a mirroring rule is added.

CI tests are skipped since there are permission issues with org/folder level resources.
Local testing was performed successfully.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [x] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [x] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
