### PR TITLE
chore: add hcledit for tf resource fixup

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -63,6 +63,25 @@ steps:
       echo -n "Folders in scope for tests:"
       find . -type d -printf '%P\n'
 
+- id: resource specific fixups
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  entrypoint: bash
+  args:
+    - -c
+    - |
+      set -e
+      mkdir -p .hcledit-tmp
+      wget -P .hcledit-tmp/ https://github.com/minamijoyo/hcledit/releases/download/v0.2.17/hcledit_0.2.17_linux_amd64.tar.gz
+      checksum=$(sha256sum .hcledit-tmp/hcledit_0.2.17_linux_amd64.tar.gz | awk '{print $1}')
+      if [ "$checksum" != "5e085bd319c84c74e87b915ab2c1f95afccb2d4326be481fbe19c1d7a0eb5fee" ]; then
+        echo "Checksum verification failed!"
+        exit 1
+      fi
+      tar -xzf .hcledit-tmp/hcledit_0.2.17_linux_amd64.tar.gz -C .hcledit-tmp/
+
+      # Add `deletion_protection = false`` to  google_container_cluste.default resources
+      find . -name "*.tf" -print | xargs -t -I {} .hcledit-tmp/hcledit attribute append resource.google_container_cluster.default.deletion_protection 'false' -u -f {} || true
+
 - id: prepare
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && prepare_environment']

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -64,23 +64,16 @@ steps:
       find . -type d -printf '%P\n'
 
 - id: resource specific fixups
-  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  name: golang:1.23
   entrypoint: bash
   args:
     - -c
     - |
       set -e
-      mkdir -p .hcledit-tmp
-      wget -P .hcledit-tmp/ https://github.com/minamijoyo/hcledit/releases/download/v0.2.17/hcledit_0.2.17_linux_amd64.tar.gz
-      checksum=$(sha256sum .hcledit-tmp/hcledit_0.2.17_linux_amd64.tar.gz | awk '{print $1}')
-      if [ "$checksum" != "5e085bd319c84c74e87b915ab2c1f95afccb2d4326be481fbe19c1d7a0eb5fee" ]; then
-        echo "Checksum verification failed!"
-        exit 1
-      fi
-      tar -xzf .hcledit-tmp/hcledit_0.2.17_linux_amd64.tar.gz -C .hcledit-tmp/
+      go install github.com/minamijoyo/hcledit@v0.2.17
 
-      # Add `deletion_protection = false`` to  google_container_cluste.default resources
-      find . -name "*.tf" -print | xargs -t -I {} .hcledit-tmp/hcledit attribute append resource.google_container_cluster.default.deletion_protection 'false' -u -f {} || true
+      # Add `deletion_protection = false` to google_container_cluster.default resources
+      find ./gke -name "*.tf" -print | xargs -t -I {} $$GOPATH/bin/hcledit attribute append resource.google_container_cluster.default.deletion_protection 'false' -u -f {} || true
 
 - id: prepare
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'

--- a/gke/autopilot/basic/main.tf
+++ b/gke/autopilot/basic/main.tf
@@ -20,9 +20,5 @@ resource "google_container_cluster" "default" {
   location = "us-central1"
 
   enable_autopilot = true
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 # [END gke_autopilot_basic]

--- a/gke/autopilot/config_sync/git/main.tf
+++ b/gke/autopilot/config_sync/git/main.tf
@@ -26,10 +26,6 @@ resource "google_container_cluster" "default" {
   }
 
   enable_autopilot = true
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 
 resource "google_gke_hub_feature" "configmanagement_feature" {

--- a/gke/autopilot/config_sync/oci/main.tf
+++ b/gke/autopilot/config_sync/oci/main.tf
@@ -26,10 +26,6 @@ resource "google_container_cluster" "default" {
   }
 
   enable_autopilot = true
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 
 resource "google_gke_hub_feature" "configmanagement_feature" {

--- a/gke/autopilot/iap/main.tf
+++ b/gke/autopilot/iap/main.tf
@@ -22,10 +22,6 @@ resource "google_container_cluster" "default" {
   location = "us-central1"
 
   enable_autopilot = true
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 
 # Required for internal ingress

--- a/gke/autopilot/labels/main.tf
+++ b/gke/autopilot/labels/main.tf
@@ -24,9 +24,5 @@ resource "google_container_cluster" "default" {
   resource_labels = {
     foo = "bar"
   }
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 # [END gke_autopilot_labels]

--- a/gke/autopilot/mesh/main.tf
+++ b/gke/autopilot/mesh/main.tf
@@ -35,10 +35,6 @@ resource "google_container_cluster" "default" {
   fleet {
     project = data.google_project.default.project_id
   }
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 
 resource "google_gke_hub_feature" "default" {

--- a/gke/autopilot/policycontroller/main.tf
+++ b/gke/autopilot/policycontroller/main.tf
@@ -36,10 +36,6 @@ resource "google_container_cluster" "default" {
   fleet {
     project = data.google_project.default.project_id
   }
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 
 resource "google_gke_hub_feature" "default" {

--- a/gke/autopilot/release_channel/main.tf
+++ b/gke/autopilot/release_channel/main.tf
@@ -24,9 +24,5 @@ resource "google_container_cluster" "default" {
   release_channel {
     channel = "REGULAR"
   }
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 # [END gke_autopilot_release_channel]

--- a/gke/autopilot/reservation/main.tf
+++ b/gke/autopilot/reservation/main.tf
@@ -21,10 +21,6 @@ resource "google_container_cluster" "default" {
   location = "us-central1"
 
   enable_autopilot = true
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 
 # [START gke_autopilot_reservation_specific_reservation]

--- a/gke/autopilot/tag/main.tf
+++ b/gke/autopilot/tag/main.tf
@@ -20,10 +20,6 @@ resource "google_container_cluster" "default" {
   location = "us-central1"
 
   enable_autopilot = true
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 
 data "google_project" "default" {}

--- a/gke/standard/regional/binary-authorization/main.tf
+++ b/gke/standard/regional/binary-authorization/main.tf
@@ -23,9 +23,5 @@ resource "google_container_cluster" "enforce" {
   binary_authorization {
     evaluation_mode = "PROJECT_SINGLETON_POLICY_ENFORCE"
   }
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 # [END gke_standard_regional_binauthz_enforce]

--- a/gke/standard/regional/gemma-tgi/main.tf
+++ b/gke/standard/regional/gemma-tgi/main.tf
@@ -29,10 +29,6 @@ resource "google_container_cluster" "default" {
   workload_identity_config {
     workload_pool = "${data.google_project.default.project_id}.svc.id.goog"
   }
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 
 resource "google_container_node_pool" "default" {

--- a/gke/standard/regional/hpa-logs/main.tf
+++ b/gke/standard/regional/hpa-logs/main.tf
@@ -23,9 +23,5 @@ resource "google_container_cluster" "default" {
   logging_config {
     enable_components = ["SYSTEM_COMPONENTS", "KCP_HPA"]
   }
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 # [END gke_standard_regional_hpa_logs]

--- a/gke/standard/regional/labels/main.tf
+++ b/gke/standard/regional/labels/main.tf
@@ -24,10 +24,6 @@ resource "google_container_cluster" "default" {
   resource_labels = {
     foo = "bar"
   }
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 # [END gke_standard_regional_labels_cluster]
 # [END gke_standard_regional_labels]

--- a/gke/standard/regional/loadbalancer/main.tf
+++ b/gke/standard/regional/loadbalancer/main.tf
@@ -22,10 +22,6 @@ resource "google_container_cluster" "default" {
   initial_node_count = 1
 
   enable_l4_ilb_subsetting = true
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 # [END gke_standard_regional_loadbalancer_cluster]
 

--- a/gke/standard/regional/multi-zone/main.tf
+++ b/gke/standard/regional/multi-zone/main.tf
@@ -20,9 +20,5 @@ resource "google_container_cluster" "default" {
   location           = "us-central1"
   node_locations     = ["us-central1-b", "us-central1-c"]
   initial_node_count = 2
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 # [END gke_standard_regional_multi_zone]

--- a/gke/standard/regional/node_pool/main.tf
+++ b/gke/standard/regional/node_pool/main.tf
@@ -25,10 +25,6 @@ resource "google_container_cluster" "default" {
 
   initial_node_count       = 1
   remove_default_node_pool = true
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 
 # [START gke_standard_regional_node_pool]

--- a/gke/standard/regional/node_system_config/main.tf
+++ b/gke/standard/regional/node_system_config/main.tf
@@ -42,10 +42,6 @@ resource "google_container_cluster" "default" {
       }
     }
   }
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 # [END gke_standard_regional_node_system_config]
 

--- a/gke/standard/regional/single-zone/main.tf
+++ b/gke/standard/regional/single-zone/main.tf
@@ -20,9 +20,5 @@ resource "google_container_cluster" "default" {
   location           = "us-west1"
   node_locations     = ["us-west1-c"]
   initial_node_count = 2
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 # [END gke_standard_regional_single_zone]

--- a/gke/standard/regional/windows/main.tf
+++ b/gke/standard/regional/windows/main.tf
@@ -21,10 +21,6 @@ resource "google_container_cluster" "default" {
   location = "us-west1"
 
   initial_node_count = 1
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 # [END gke_standard_regional_windows_cluster]
 

--- a/gke/standard/zonal/arm/main.tf
+++ b/gke/standard/zonal/arm/main.tf
@@ -31,10 +31,6 @@ resource "google_container_cluster" "default" {
     machine_type    = "t2a-standard-1"
     service_account = google_service_account.default.email
   }
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 # [END gke_standard_zonal_arm_cluster]
 

--- a/gke/standard/zonal/gpu/main.tf
+++ b/gke/standard/zonal/gpu/main.tf
@@ -30,9 +30,5 @@ resource "google_container_cluster" "default" {
     }
     machine_type = "n1-standard-2"
   }
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 # [END gke_standard_zonal_gpu]

--- a/gke/standard/zonal/multi-zone/main.tf
+++ b/gke/standard/zonal/multi-zone/main.tf
@@ -20,9 +20,5 @@ resource "google_container_cluster" "default" {
   location           = "us-central1-a"
   node_locations     = ["us-central1-b", "us-central1-c"]
   initial_node_count = 2
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 # [END gke_standard_zonal_multi_zone]

--- a/gke/standard/zonal/node_image/main.tf
+++ b/gke/standard/zonal/node_image/main.tf
@@ -22,9 +22,5 @@ resource "google_container_cluster" "default" {
   node_config {
     image_type = "cos_containerd"
   }
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 # [END gke_standard_zonal_node_image]

--- a/gke/standard/zonal/reservation/main.tf
+++ b/gke/standard/zonal/reservation/main.tf
@@ -47,10 +47,6 @@ resource "google_container_cluster" "default" {
   depends_on = [
     google_compute_reservation.any_reservation
   ]
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 # [END gke_standard_zonal_reservation_any_cluster]
 

--- a/gke/standard/zonal/secondary-boot-disk/main.tf
+++ b/gke/standard/zonal/secondary-boot-disk/main.tf
@@ -23,10 +23,6 @@ resource "google_container_cluster" "default" {
   # secondary_boot_disks require GKE 1.28.3-gke.106700 or later, which should
   # be true for all release channels apart from EXTENDED.
   # If required, Use `release_channel = "EXTENDED"` and set `min_master_version`.
-
-  # Setting `deletion_protection` to `true` would prevent
-  # accidental deletion of this instance using Terraform.
-  deletion_protection = false
 }
 # [END gke_standard_zonal_secondary_boot_disk_cluster]
 

--- a/gke/standard/zonal/single-zone/main.tf
+++ b/gke/standard/zonal/single-zone/main.tf
@@ -19,9 +19,5 @@ resource "google_container_cluster" "default" {
   name               = "gke-standard-zonal-single-zone"
   location           = "us-central1-a"
   initial_node_count = 1
-
-  # Set `deletion_protection` to `true` will ensure that one cannot
-  # accidentally delete this instance by use of Terraform.
-  deletion_protection = false
 }
 # [END gke_standard_zonal_single_zone]


### PR DESCRIPTION
## Description

Fixes b/401371689

- add hcledit step for tf resource fixup
- migrate `deletion_protection = false` for non-quickstart google_container_cluster.default

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [x] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [x] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
