### PR TITLE
chore(ci): Run all tests for .github/workflows, not .github/*

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -36,7 +36,7 @@ steps:
 
       # Do not prune if changing tests themselves
       while read d; do
-        if [[ "build test .github" =~ "${d%/}" ]]; then
+        if [[ "build test .github/workflows" =~ "${d%/}" ]]; then
           echo "Infrastructure folder ${d%/} has changed; no tests will be pruned."
           exit 0 # do not prune
         fi


### PR DESCRIPTION
Files directly in .github/* are not related to code execution changes, but files in .github/workflows/* are. 

Prevents full test execution on changes to CODEOWNERS

## Description

Fixes issues like #853 running all tests


- [x] Yes, **merge** this PR after it is approved
