### PR TITLE
chore(ci): adjust validation of test changes

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -35,9 +35,8 @@ steps:
       cat _changed_folders
 
       # Do not prune if changing tests themselves
-      git diff --quiet origin/main build test .github/workflows
-      _CHANGED=$?
-      if [[ "${_CHANGED}" -ne 0 ]]; then
+      _build_changes=$(git diff --quiet origin/main build test .github/workflows)
+      if [[ -n "${_build_changes}" ]]; then
           echo "Infrastructure folders have changed; no tests will be pruned."
           exit 0 # do not prune
       fi

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -36,8 +36,8 @@ steps:
 
       # Do not prune if changing tests themselves
       git diff --quiet origin/main build test .github/workflows
-      CHANGED=$?
-      if [[ "${CHANGED}" -ne 0 ]]; then
+      _CHANGED=$?
+      if [[ "${_CHANGED}" -ne 0 ]]; then
           echo "Infrastructure folders have changed; no tests will be pruned."
           exit 0 # do not prune
       fi

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -35,7 +35,9 @@ steps:
       cat _changed_folders
 
       # Do not prune if changing tests themselves
+      set +e
       _build_changes=$(git diff --quiet origin/main build test .github/workflows)
+      set -e
       if [[ -n "${_build_changes}" ]]; then
           echo "Infrastructure folders have changed; no tests will be pruned."
           exit 0 # do not prune

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -36,7 +36,7 @@ steps:
 
       # Do not prune if changing tests themselves
       set +e
-      _build_changes=$(git diff --quiet origin/main build test .github/workflows)
+      _build_changes=$(git diff origin/main build test .github/workflows)
       set -e
       if [[ -n "${_build_changes}" ]]; then
           echo "Infrastructure folders have changed; no tests will be pruned."

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -35,12 +35,12 @@ steps:
       cat _changed_folders
 
       # Do not prune if changing tests themselves
-      while read d; do
-        if [[ "build test .github/workflows" =~ "${d%/}" ]]; then
-          echo "Infrastructure folder ${d%/} has changed; no tests will be pruned."
+      git diff --quiet origin/main build test .github/workflows
+      CHANGED=$?
+      if [[ "${CHANGED}" -ne 0 ]]; then
+          echo "Infrastructure folders have changed; no tests will be pruned."
           exit 0 # do not prune
-        fi
-      done < _changed_folders
+      fi
 
       # Remove base folders without changes
       for d in *; do


### PR DESCRIPTION
Borrowed from python-docs-samples https://github.com/GoogleCloudPlatform/python-docs-samples/blob/a163a4247af1ccdcb6138756e0adf75604069326/.kokoro/tests/run_tests.sh#L35

Should ensure that changes to CODEOWNERS only in .github (and other meta config files) don't fire all tests (blocks new sample onboarding)

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved
