### PR TITLE
feat(backupdr): Add disks example code for backup-plan and backup-plan-association

### DIFF
--- a/backupdr/backup_plan/main.tf
+++ b/backupdr/backup_plan/main.tf
@@ -67,3 +67,32 @@ resource "google_backup_dr_backup_plan" "default" {
 }
 
 # [END backupdr_create_backupplan]
+
+# [START backupdr_create_backupplan_disk]
+
+# Before creating a backup plan, you need to create backup vault (google_backup_dr_backup_vault).
+resource "google_backup_dr_backup_plan" "disk_default" {
+  provider       = google-beta
+  location       = "us-central1"
+  backup_plan_id = "my-disk-bp"
+  resource_type  = "compute.googleapis.com/Disk"
+  backup_vault   = google_backup_dr_backup_vault.default.name
+
+  backup_rules {
+    rule_id               = "rule-1"
+    backup_retention_days = 5
+
+    standard_schedule {
+      recurrence_type  = "HOURLY"
+      hourly_frequency = 1
+      time_zone        = "UTC"
+
+      backup_window {
+        start_hour_of_day = 0
+        end_hour_of_day   = 6
+      }
+    }
+  }
+}
+
+# [END backupdr_create_backupplan_disk]

--- a/backupdr/backup_plan/test.yaml
+++ b/backupdr/backup_plan/test.yaml
@@ -1,0 +1,20 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintTest
+metadata:
+  name: backupdr_backup_plan
+spec:
+  skip: true

--- a/backupdr/backup_plan_association/main.tf
+++ b/backupdr/backup_plan_association/main.tf
@@ -57,7 +57,6 @@ resource "google_compute_disk" "default" {
   name = "disk-data"
   type = "pd-standard"
   zone = "us-central1-a"
-  size = "5"
 }
 
 resource "google_backup_dr_backup_vault" "default" {

--- a/backupdr/backup_plan_association/main.tf
+++ b/backupdr/backup_plan_association/main.tf
@@ -148,7 +148,7 @@ resource "google_backup_dr_backup_plan_association" "default" {
 
 # Before creating a backup plan association, you need to create backup plan (google_backup_dr_backup_plan)
 # and compute disk (google_compute_disk or google_compute_region_disk).
-resource "google_backup_dr_backup_plan_association" "default" {
+resource "google_backup_dr_backup_plan_association" "disk_association" {
   provider                   = google-beta
   location                   = "us-central1"
   backup_plan_association_id = "my-disk-bpa"

--- a/backupdr/backup_plan_association/main.tf
+++ b/backupdr/backup_plan_association/main.tf
@@ -53,6 +53,13 @@ resource "google_compute_instance" "default" {
   }
 }
 
+resource "google_compute_disk" "default" {
+  name = "disk-data"
+  type = "pd-standard"
+  zone = "us-west1-a"
+  size = "5"
+}
+
 resource "google_backup_dr_backup_vault" "default" {
   provider                                   = google-beta
   location                                   = "us-central1"
@@ -99,6 +106,30 @@ resource "google_backup_dr_backup_plan" "default" {
   }
 }
 
+resource "google_backup_dr_backup_plan" "disk_default" {
+  provider       = google-beta
+  location       = "us-central1"
+  backup_plan_id = "my-disk-bp"
+  resource_type  = "compute.googleapis.com/Disk"
+  backup_vault   = google_backup_dr_backup_vault.default.name
+
+  backup_rules {
+    rule_id               = "rule-1"
+    backup_retention_days = 5
+
+    standard_schedule {
+      recurrence_type  = "HOURLY"
+      hourly_frequency = 1
+      time_zone        = "UTC"
+
+      backup_window {
+        start_hour_of_day = 0
+        end_hour_of_day   = 6
+      }
+    }
+  }
+}
+
 # [START backupdr_create_backupplanassociation]
 
 # Before creating a backup plan association, you need to create backup plan (google_backup_dr_backup_plan)
@@ -113,3 +144,18 @@ resource "google_backup_dr_backup_plan_association" "default" {
 }
 
 # [END backupdr_create_backupplanassociation]
+
+# [START backupdr_create_backupplanassociation_disk]
+
+# Before creating a backup plan association, you need to create backup plan (google_backup_dr_backup_plan)
+# and compute disk (google_compute_disk or google_compute_region_disk).
+resource "google_backup_dr_backup_plan_association" "default" {
+  provider                   = google-beta
+  location                   = "us-central1"
+  backup_plan_association_id = "my-disk-bpa"
+  resource                   = google_compute_disk.default.id
+  resource_type              = "compute.googleapis.com/Disk"
+  backup_plan                = google_backup_dr_backup_plan.disk_default.name
+}
+
+# [END backupdr_create_backupplanassociation_disk]

--- a/backupdr/backup_plan_association/main.tf
+++ b/backupdr/backup_plan_association/main.tf
@@ -56,7 +56,7 @@ resource "google_compute_instance" "default" {
 resource "google_compute_disk" "default" {
   name = "disk-data"
   type = "pd-standard"
-  zone = "us-west1-a"
+  zone = "us-central1-a"
   size = "5"
 }
 

--- a/backupdr/backup_plan_association/test.yaml
+++ b/backupdr/backup_plan_association/test.yaml
@@ -1,0 +1,20 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintTest
+metadata:
+  name: backupdr_backup_plan_association
+spec:
+  skip: true


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

-  [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [ ] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [ ] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [ ] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): https://cloud.devsite.corp.google.com/backup-disaster-recovery/docs/cloud-console/compute/disk-backup#configure_a_scheduled_backup

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
