### PR TITLE
feat: Add TF samples for creating a Looker (Google Cloud core) Enterprise instance that uses PSC

### DIFF
--- a/looker/looker-core-psc/main.tf
+++ b/looker/looker-core-psc/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/looker/looker-core-psc/main.tf
+++ b/looker/looker-core-psc/main.tf
@@ -29,6 +29,6 @@ resource "google_looker_instance" "default" {
   psc_config {
     # allowed_vpcs = ["projects/{project}/global/networks/{network}"]
     # (Optional) List of VPCs that are allowed ingress into the Looker instance. Set an allowed VPC if you are creating an instance that uses only private IP.
-   }
+  }
 }
 # [END looker_google_looker_instance_psc]

--- a/looker/looker-core-psc/main.tf
+++ b/looker/looker-core-psc/main.tf
@@ -1,4 +1,4 @@
-/**
+ /**
  * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,8 +28,9 @@ resource "google_looker_instance" "default" {
   }
   psc_config {
     allowed_vpcs = ["projects/test-project/global/networks/test"]
-    # update only
-    # service_attachments = [{local_fqdn: "www.local-fqdn.com" target_service_attachment_uri: "projects/my-project/regions/us-east1/serviceAttachments/sa"}]
-  }
+    # (Optional) List of VPCs that are allowed ingress into the Looker instance.
+    service_attachments = [{local_fqdn: "www.local-fqdn.com" target_service_attachment_uri: "projects/my-project/regions/us-east1/serviceAttachments/sa"}]
+    # (Optional) List of egress service attachment configurations. local_fqdn is a fully qualified domain name that will be used in the private DNS record created for the service attachment. target_service_attachment_uri is the URI of the service attachment to connect to.
+   }
 }
 # [END looker_google_looker_instance_psc]

--- a/looker/looker-core-psc/main.tf
+++ b/looker/looker-core-psc/main.tf
@@ -1,4 +1,4 @@
- /**
+/**
  * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/looker/looker-core-psc/main.tf
+++ b/looker/looker-core-psc/main.tf
@@ -27,10 +27,8 @@ resource "google_looker_instance" "default" {
     client_secret = "my-client-secret"
   }
   psc_config {
-    allowed_vpcs = ["projects/test-project/global/networks/test"]
-    # (Optional) List of VPCs that are allowed ingress into the Looker instance.
-    service_attachments = [{local_fqdn: "www.local-fqdn.com" target_service_attachment_uri: "projects/my-project/regions/us-east1/serviceAttachments/sa"}]
-    # (Optional) List of egress service attachment configurations. local_fqdn is a fully qualified domain name that will be used in the private DNS record created for the service attachment. target_service_attachment_uri is the URI of the service attachment to connect to.
+    # allowed_vpcs = ["projects/{project}/global/networks/{network}"]
+    # (Optional) List of VPCs that are allowed ingress into the Looker instance. Set an allowed VPC if you are creating an instance that uses only private IP.
    }
 }
 # [END looker_google_looker_instance_psc]

--- a/looker/looker-core-psc/main.tf
+++ b/looker/looker-core-psc/main.tf
@@ -15,7 +15,7 @@
  */
 # [START looker_google_looker_instance_psc]
 # Create an ENTERPRISE edition Looker (Google Cloud core) instance that has PSC enabled.
-resource "google_looker_instance" "main" {
+resource "google_looker_instance" "default" {
   name               = "my-instance"
   platform_edition   = "LOOKER_CORE_ENTERPRISE_ANNUAL"
   region             = "us-central1"

--- a/looker/looker-core-psc/main.tf
+++ b/looker/looker-core-psc/main.tf
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+# [START looker_google_looker_instance_psc]
+# Create an ENTERPRISE edition Looker (Google Cloud core) instance that has PSC enabled.
+resource "google_looker_instance" "main" {
+  name               = "my-instance"
+  platform_edition   = "LOOKER_CORE_ENTERPRISE_ANNUAL"
+  region             = "us-central1"
+  private_ip_enabled = false
+  public_ip_enabled  = false
+  psc_enabled        = true
+  oauth_config {
+    client_id     = "my-client-id"
+    client_secret = "my-client-secret"
+  }
+  psc_config {
+    allowed_vpcs = ["projects/test-project/global/networks/test"]
+    # update only
+    # service_attachments = [{local_fqdn: "www.local-fqdn.com" target_service_attachment_uri: "projects/my-project/regions/us-east1/serviceAttachments/sa"}]
+  }
+}
+# [END looker_google_looker_instance_psc]

--- a/looker/looker-core-psc/test.yaml
+++ b/looker/looker-core-psc/test.yaml
@@ -15,6 +15,6 @@
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintTest
 metadata:
-  name: looker_instance_psc
+  name: looker_core_psc
 spec:
   skip: true

--- a/looker/looker-core-psc/test.yaml
+++ b/looker/looker-core-psc/test.yaml
@@ -1,0 +1,20 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintTest
+metadata:
+  name: looker_instance_psc
+spec:
+  skip: true


### PR DESCRIPTION
## Description

Fixes b/429215192

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [x] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [x] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
