### PR TITLE
docs: Add MKC Samples for Creating Connectors

### DIFF
--- a/managedkafka/managedkafka_create_connector_bigquery_sink/main.tf
+++ b/managedkafka/managedkafka_create_connector_bigquery_sink/main.tf
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# [START managedkafkaconnect_create_connector_bigquery_sink_parent]
+data "google_project" "default" {
+  provider = google-beta
+}
+
+resource "google_managed_kafka_cluster" "default" {
+  project    = data.google_project.default.project_id
+  cluster_id = "my-cluster-id"
+  location   = "us-central1"
+  capacity_config {
+    vcpu_count   = 3
+    memory_bytes = 3221225472 # 3 GiB
+  }
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/${data.google_project.default.number}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+}
+
+resource "google_managed_kafka_connect_cluster" "default" {
+  provider           = google-beta
+  project            = data.google_project.default.project_id
+  connect_cluster_id = "my-connect-cluster-id"
+  location           = "us-central1"
+  kafka_cluster      = google_managed_kafka_cluster.default.id
+  capacity_config {
+    vcpu_count   = 3
+    memory_bytes = 2884901888 # 12 GiB
+  }
+  gcp_config {
+    access_config {
+      network_configs {
+        primary_subnet = "projects/${data.google_project.default.number}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+}
+# [END managedkafkaconnect_create_connector_bigquery_sink_parent]
+
+# [START managedkafkaconnect_create_connector_bigquery_sink]
+resource "google_managed_kafka_connector" "example-bigquery-sink-connector" {
+  project            = data.google_project.default.project_id
+  connector_id    = "my-bigquery-sink-connector"
+  connect_cluster = google_managed_kafka_connect_cluster.default.connect_cluster_id
+  location        = "us-central1"
+
+  configs = {
+    "name"                          = "my-bigquery-sink-connector"
+    "project"                       = "GCP_PROJECT_ID"
+    "topics"                        = "GMK_TOPIC_ID"
+    "tasks.max"                     = "3"
+    "connector.class"               = "com.wepay.kafka.connect.bigquery.BigQuerySinkConnector"
+    "key.converter"                 = "org.apache.kafka.connect.storage.StringConverter"
+    "value.converter"               = "org.apache.kafka.connect.json.JsonConverter"
+    "value.converter.schemas.enable"= "false"
+    "defaultDataset"                = "BQ_DATASET_ID"
+  }
+
+  provider = google-beta
+}
+# [END managedkafkaconnect_create_connector_bigquery_sink]

--- a/managedkafka/managedkafka_create_connector_cloud_storage_sink/main.tf
+++ b/managedkafka/managedkafka_create_connector_cloud_storage_sink/main.tf
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# [START managedkafkaconnect_create_connector_cloud_storage_sink_parent]
+data "google_project" "default" {
+  provider = google-beta
+}
+
+resource "google_managed_kafka_cluster" "default" {
+  project    = data.google_project.default.project_id
+  cluster_id = "my-cluster-id"
+  location   = "us-central1"
+  capacity_config {
+    vcpu_count   = 3
+    memory_bytes = 3221225472 # 3 GiB
+  }
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/${data.google_project.default.number}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+}
+
+resource "google_managed_kafka_connect_cluster" "default" {
+  provider           = google-beta
+  project            = data.google_project.default.project_id
+  connect_cluster_id = "my-connect-cluster-id"
+  location           = "us-central1"
+  kafka_cluster      = google_managed_kafka_cluster.default.id
+  capacity_config {
+    vcpu_count   = 12
+    memory_bytes = 2884901888 # 12 GiB
+  }
+  gcp_config {
+    access_config {
+      network_configs {
+        primary_subnet = "projects/${data.google_project.default.number}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+}
+# [END managedkafkaconnect_create_connector_cloud_storage_sink_parent]
+
+# [START managedkafkaconnect_create_connector_cloud_storage_sink]
+resource "google_managed_kafka_connector" "example-cloud-storage-sink-connector" {
+  project            = data.google_project.default.project_id
+  connector_id    = "my-gcs-sink-connector"
+  connect_cluster = google_managed_kafka_connect_cluster.default.connect_cluster_id
+  location        = "us-central1"
+
+  configs = {
+    "connector.class"               = "io.aiven.kafka.connect.gcs.GcsSinkConnector"
+    "tasks.max"                     = "1"
+    "topics"                        = "GMK_TOPIC_ID"
+    "gcs.bucket.name"               = "GCS_BUCKET_NAME"
+    "gcs.credentials.default"       = "true"
+    "format.output.type"            = "json"
+    "name"                          = "my-gcs-sink-connector"
+    "value.converter"               = "org.apache.kafka.connect.json.JsonConverter"
+    "value.converter.schemas.enable"= "false"
+    "key.converter"                 = "org.apache.kafka.connect.storage.StringConverter"
+  }
+  provider = google-beta
+}
+# [END managedkafkaconnect_create_connector_cloud_storage_sink]

--- a/managedkafka/managedkafka_create_connector_mirrormaker/main.tf
+++ b/managedkafka/managedkafka_create_connector_mirrormaker/main.tf
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# [START managedkafkaconnect_create_connector_mirrormaker_parent]
+data "google_project" "default" {
+  provider = google-beta
+}
+
+resource "google_managed_kafka_cluster" "default" {
+  project    = data.google_project.default.project_id
+  cluster_id = "my-cluster-id"
+  location   = "us-central1"
+  capacity_config {
+    vcpu_count   = 3
+    memory_bytes = 3221225472 # 3 GiB
+  }
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/${data.google_project.default.number}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+}
+
+resource "google_managed_kafka_connect_cluster" "default" {
+  provider           = google-beta
+  project            = data.google_project.default.project_id
+  connect_cluster_id = "my-connect-cluster-id"
+  location           = "us-central1"
+  kafka_cluster      = google_managed_kafka_cluster.default.id
+  capacity_config {
+    vcpu_count   = 12
+    memory_bytes = 2884901888 # 12 GiB
+  }
+  gcp_config {
+    access_config {
+      network_configs {
+        primary_subnet = "projects/${data.google_project.default.number}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+}
+# [END managedkafkaconnect_create_connector_mirrormaker_parent]
+
+# [START managedkafkaconnect_create_connector_mirrormaker]
+resource "google_managed_kafka_connector" "default" {
+  project         = data.google_project.default.project_id
+  connector_id    = "MM2_CONNECTOR_ID"
+  connect_cluster = google_managed_kafka_connect_cluster.default.connect_cluster_id
+  location        = "us-central1"
+
+  configs = {
+    "connector.class"                              = "org.apache.kafka.connect.mirror.MirrorSourceConnector"
+    "name"                                         = "MM2_CONNECTOR_ID"
+    "source.cluster.alias"                         = "source"
+    "target.cluster.alias"                         = "target"
+    "topics"                                       = "GMK_TOPIC_NAME"
+    "source.cluster.bootstrap.servers"             = "GMK_SOURCE_CLUSTER_DNS"
+    "target.cluster.bootstrap.servers"             = "GMK_TARGET_CLUSTER_DNS"
+    "offset-syncs.topic.replication.factor"        = "1"
+    "source.cluster.security.protocol"             = "SASL_SSL"
+    "source.cluster.sasl.mechanism"                = "OAUTHBEARER"
+    "source.cluster.sasl.login.callback.handler.class" = "com.google.cloud.hosted.kafka.auth.GcpLoginCallbackHandler"
+    "source.cluster.sasl.jaas.config"              = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;"
+    "target.cluster.security.protocol"             = "SASL_SSL"
+    "target.cluster.sasl.mechanism"                = "OAUTHBEARER"
+    "target.cluster.sasl.login.callback.handler.class" = "com.google.cloud.hosted.kafka.auth.GcpLoginCallbackHandler"
+    "target.cluster.sasl.jaas.config"              = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;"
+  }
+
+  provider = google-beta
+}
+# [END managedkafkaconnect_create_connector_mirrormaker]

--- a/managedkafka/managedkafka_create_connector_pubsub_sink/main.tf
+++ b/managedkafka/managedkafka_create_connector_pubsub_sink/main.tf
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# [START managedkafkaconnect_create_connector_pubsub_sink_parent]
+data "google_project" "default" {
+  provider = google-beta
+}
+
+resource "google_managed_kafka_cluster" "default" {
+  project    = data.google_project.default.project_id
+  cluster_id = "my-cluster-id"
+  location   = "us-central1"
+  capacity_config {
+    vcpu_count   = 3
+    memory_bytes = 3221225472 # 3 GiB
+  }
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/${data.google_project.default.number}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+}
+
+resource "google_managed_kafka_connect_cluster" "default" {
+  provider           = google-beta
+  project            = data.google_project.default.project_id
+  connect_cluster_id = "my-connect-cluster-id"
+  location           = "us-central1"
+  kafka_cluster      = google_managed_kafka_cluster.default.id
+  capacity_config {
+    vcpu_count   = 12
+    memory_bytes = 2884901888 # 12 GiB
+  }
+  gcp_config {
+    access_config {
+      network_configs {
+        primary_subnet = "projects/${data.google_project.default.number}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+}
+
+# [END managedkafkaconnect_create_connector_pubsub_sink_parent]
+
+# [START managedkafkaconnect_create_connector_pubsub_sink]
+resource "google_managed_kafka_connector" "example-pubsub-sink-connector" {
+  project            = data.google_project.default.project_id
+  connector_id    = "my-pubsub-sink-connector"
+  connect_cluster = google_managed_kafka_connect_cluster.default.connect_cluster_id
+  location        = "us-central1"
+
+  configs = {
+    "connector.class" = "com.google.pubsub.kafka.sink.CloudPubSubSinkConnector"
+    "name" = "my-pubsub-sink-connector"
+    "tasks.max" = "1"
+    "topics" = "TOPIC_NAME"
+    "cps.topic" = "CPS_TOPIC_NAME"
+    "cps.project" = "CPS_PROJECT_NAME"
+    "value.converter" = "org.apache.kafka.connect.storage.StringConverter"
+    "key.converter" = "org.apache.kafka.connect.storage.StringConverter"
+  }
+  
+  provider = google-beta
+}
+# [END managedkafkaconnect_create_connector_pubsub_sink]

--- a/managedkafka/managedkafka_create_connector_pubsub_source/main.tf
+++ b/managedkafka/managedkafka_create_connector_pubsub_source/main.tf
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# [START managedkafkaconnect_create_connector_pubsub_source_parent]
+data "google_project" "default" {
+  provider = google-beta
+}
+
+resource "google_managed_kafka_cluster" "default" {
+  project    = data.google_project.default.project_id
+  cluster_id = "my-cluster-id"
+  location   = "us-central1"
+  capacity_config {
+    vcpu_count   = 3
+    memory_bytes = 3221225472 # 3 GiB
+  }
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/${data.google_project.default.number}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+}
+
+resource "google_managed_kafka_connect_cluster" "default" {
+  provider           = google-beta
+  project            = data.google_project.default.project_id
+  connect_cluster_id = "my-connect-cluster-id"
+  location           = "us-central1"
+  kafka_cluster      = google_managed_kafka_cluster.default.id
+  capacity_config {
+    vcpu_count   = 12
+    memory_bytes = 2884901888 # 12 GiB
+  }
+  gcp_config {
+    access_config {
+      network_configs {
+        primary_subnet = "projects/${data.google_project.default.number}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+}
+
+# [END managedkafkaconnect_create_connector_pubsub_source_parent] 
+
+# [START managedkafkaconnect_create_connector_pubsub_source] 
+resource "google_managed_kafka_connector" "example-pubsub-source-connector" {
+  project            = data.google_project.default.project_id
+  connector_id    = "my-pubsub-source-connector"
+  connect_cluster = google_managed_kafka_connect_cluster.default.connect_cluster_id
+  location        = "us-central1"
+
+  configs = {
+    "connector.class" = "com.google.pubsub.kafka.source.CloudPubSubSourceConnector"
+    "name" = "my-pubsub-source-connector"
+    "tasks.max" = "1"
+    "kafka.topic" = "GMK_TOPIC_ID"
+    "cps.subscription" = "CPS_SUBSCRIPTION_ID"
+    "cps.project" = "GCP_PROJECT_ID"
+    "value.converter" = "org.apache.kafka.connect.converters.ByteArrayConverter"
+    "key.converter = "org.apache.kafka.connect.storage.StringConverter"
+  }
+  
+  provider = google-beta
+}
+# [END managedkafkaconnect_create_connector_pubsub_source] 


### PR DESCRIPTION
Adds Terraform samples for Managed Kafka Connect
to create connectors for BigQuery, Cloud Storage, MirrorMaker,
Pub/Sub Sink, and Pub/Sub Source.

## Description

Fixes https://b.corp.google.com/issues/430087669

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [ ] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [X] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [X] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [ ] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [X] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [X] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [X] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):
* https://cloud.google.com/managed-service-for-apache-kafka/docs/connect-cluster/create-mirrormaker-connector
* https://cloud.google.com/managed-service-for-apache-kafka/docs/connect-cluster/create-pubsub-source-connector
* https://cloud.google.com/managed-service-for-apache-kafka/docs/connect-cluster/create-pubsub-sink-connector
* https://cloud.google.com/managed-service-for-apache-kafka/docs/connect-cluster/create-cloud-storage-connector
* https://cloud.google.com/managed-service-for-apache-kafka/docs/connect-cluster/create-bq-connector

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
