### PR TITLE
fix(managedkafka): use data resources for project IDs

### DIFF
--- a/managedkafka/managedkafka_create_connector_bigquery_sink/main.tf
+++ b/managedkafka/managedkafka_create_connector_bigquery_sink/main.tf
@@ -80,7 +80,7 @@ resource "google_managed_kafka_connector" "example-bigquery-sink-connector" {
 
   configs = {
     "name"                           = "my-bigquery-sink-connector"
-    "project"                        = "GCP_PROJECT_ID"
+    "project"                        = data.google_project.default.project_id
     "topics"                         = "GMK_TOPIC_ID"
     "tasks.max"                      = "3"
     "connector.class"                = "com.wepay.kafka.connect.bigquery.BigQuerySinkConnector"

--- a/managedkafka/managedkafka_create_connector_pubsub_source/main.tf
+++ b/managedkafka/managedkafka_create_connector_pubsub_source/main.tf
@@ -84,7 +84,7 @@ resource "google_managed_kafka_connector" "example-pubsub-source-connector" {
     "tasks.max"        = "3"
     "kafka.topic"      = "GMK_TOPIC_ID"
     "cps.subscription" = "CPS_SUBSCRIPTION_ID"
-    "cps.project"      = "GCP_PROJECT_ID"
+    "cps.project"      = data.google_project.default.project_id
     "value.converter"  = "org.apache.kafka.connect.converters.ByteArrayConverter"
     "key.converter"    = "org.apache.kafka.connect.storage.StringConverter"
   }


### PR DESCRIPTION
## Description
Follow up to #878, remove the hardcoded project IDs when the value should match the value used in the parent level arguments. 

**Readiness**

- [x] Yes, **merge** this PR after it is approved

