### PR TITLE
docs: Change Cloud Scheduler region from us-central1 to us-east1

### DIFF
--- a/cloud_scheduler/basic/main.tf
+++ b/cloud_scheduler/basic/main.tf
@@ -53,7 +53,7 @@ resource "google_cloud_scheduler_job" "default" {
   name        = "test-job"
   description = "test job"
   schedule    = "30 16 * * 7"
-  region      = "us-central1"
+  region      = "us-east1"
 
   pubsub_target {
     topic_name = google_pubsub_topic.default.id

--- a/cloud_scheduler/basic/main.tf
+++ b/cloud_scheduler/basic/main.tf
@@ -61,3 +61,20 @@ resource "google_cloud_scheduler_job" "default" {
   }
 }
 # [END cloudscheduler_terraform_basic_job]
+
+# Cloud Scheduler invokes the job, but then the job runs asynchronously
+# We cannot delete the running job
+# Wait 5 minutes before completing the 'apply' step
+
+resource "time_sleep" "wait_for_scheduler_api" {
+  create_duration = "300s"
+
+  depends_on = [
+    google_cloud_scheduler_job.default,
+    google_pubsub_subscription.default,
+  ]
+}
+
+resource "null_resource" "test_sync_anchor" {
+  depends_on = [time_sleep.wait_for_scheduler_api]
+}


### PR DESCRIPTION


## Description

Fixes b/507114306

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [x ] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x ] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [ x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [ x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [ x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [ x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): https://docs.cloud.google.com/scheduler/docs/schedule-run-cron-job-terraform

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
