### PR TITLE
Fix typo in comment

### DIFF
--- a/workloadidentity/generate_service_agents/main.tf
+++ b/workloadidentity/generate_service_agents/main.tf
@@ -15,7 +15,7 @@
  */
 
 /*
-Create all service agents for aiplatform.googleapis.com for
+Create all service agents for bigquery.googleapis.com for
 the `default` project, then grant roles to the service agents.
 */
 


### PR DESCRIPTION
The comment in line 18 currently references aiplatform.googleapis.com while the sample uses bigquery.googleapis.com.

**Readiness**

- [X] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved