### PR TITLE
feat(bigtable): Add example for creating an instance with tags

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 /test/                        @terraform-google-modules/terraform-samples-git-admins @terraform-google-modules/cft-admins @terraform-google-modules/cloud-samples-infra
 /build/                       @terraform-google-modules/terraform-samples-git-admins @terraform-google-modules/cft-admins @terraform-google-modules/cloud-samples-infra
 
+/bigtable/                    @terraform-google-modules/bigtable-terraform-swe @terraform-google-modules/terraform-samples-reviewers
 /bigquery/                    @terraform-google-modules/bigquery-terraform-swe @terraform-google-modules/terraform-samples-reviewers
 /cloud_sql/                   @terraform-google-modules/cloudsql-connectivity @terraform-google-modules/terraform-samples-reviewers
 /cloudvpn/                    @terraform-google-modules/dee-infra @terraform-google-modules/terraform-samples-reviewers

--- a/bigtable/bigtable_create_instance/main.tf
+++ b/bigtable/bigtable_create_instance/main.tf
@@ -28,12 +28,11 @@ resource "google_tags_tag_value" "env_tag_value" {
   short_name = "prod"
 }
 
-
 resource "google_bigtable_instance" "instance" {
   name                = "my-bigtable-instance"
   deletion_protection = false
   tags = {
-     (google_tags_tag_key.env_tag_key.namespaced_name) : google_tags_tag_value.env_tag_value.short_name
+    (google_tags_tag_key.env_tag_key.namespaced_name) : google_tags_tag_value.env_tag_value.short_name
   }
 
   cluster {

--- a/bigtable/bigtable_create_instance/main.tf
+++ b/bigtable/bigtable_create_instance/main.tf
@@ -1,0 +1,47 @@
+/**
+* Copyright 2026 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+# [START bigtable_create_instance_attach_tag]
+
+data "google_project" "default" {}
+
+resource "google_tags_tag_key" "env_tag_key" {
+  parent     = "projects/${data.google_project.default.project_id}"
+  short_name = "env"
+}
+
+resource "google_tags_tag_value" "env_tag_value" {
+  parent     = "tagKeys/${google_tags_tag_key.env_tag_key.name}"
+  short_name = "prod"
+}
+
+
+resource "google_bigtable_instance" "instance" {
+  name                = "my-bigtable-instance"
+  deletion_protection = false
+  tags = {
+     (google_tags_tag_key.env_tag_key.namespaced_name) : google_tags_tag_value.env_tag_value.short_name
+  }
+
+  cluster {
+    cluster_id   = "my-cluster"
+    zone         = "us-central1-a"
+    num_nodes    = 1
+    storage_type = "SSD"
+  }
+}
+
+# [END bigtable_create_instance_attach_tag]

--- a/bigtable/bigtable_create_instance/main.tf
+++ b/bigtable/bigtable_create_instance/main.tf
@@ -19,14 +19,14 @@
 data "google_project" "default" {}
 
 resource "google_tags_tag_key" "env_tag_key" {
-  parent     = "projects/${data.google_project.default.project_id}"
-  short_name = "env"
+  parent          = "projects/${data.google_project.default.project_id}"
+  short_name      = "env"
   deletion_policy = "ABANDON"
 }
 
 resource "google_tags_tag_value" "env_tag_value" {
-  parent     = "tagKeys/${google_tags_tag_key.env_tag_key.name}"
-  short_name = "prod"
+  parent          = "tagKeys/${google_tags_tag_key.env_tag_key.name}"
+  short_name      = "prod"
   deletion_policy = "ABANDON"
 }
 

--- a/bigtable/bigtable_create_instance/main.tf
+++ b/bigtable/bigtable_create_instance/main.tf
@@ -21,11 +21,13 @@ data "google_project" "default" {}
 resource "google_tags_tag_key" "env_tag_key" {
   parent     = "projects/${data.google_project.default.project_id}"
   short_name = "env"
+  deletion_policy = "ABANDON"
 }
 
 resource "google_tags_tag_value" "env_tag_value" {
   parent     = "tagKeys/${google_tags_tag_key.env_tag_key.name}"
   short_name = "prod"
+  deletion_policy = "ABANDON"
 }
 
 resource "google_bigtable_instance" "instance" {

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -44,6 +44,7 @@ module "projects" {
     "artifactregistry.googleapis.com",
     "backupdr.googleapis.com",
     "biglake.googleapis.com",
+    "bigtableadmin.googleapis.com",
     "bigquery.googleapis.com",
     "bigqueryconnection.googleapis.com",
     "certificatemanager.googleapis.com",


### PR DESCRIPTION
## Description

This PR adds an example on how to create and bind tags to a Bigtable instance on creation.

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [ ] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
