### PR TITLE
fix: terraform_unused_declarations lint

### DIFF
--- a/securitycenter/securitycenter_v2_endpoint_us/main.tf
+++ b/securitycenter/securitycenter_v2_endpoint_us/main.tf
@@ -1,3 +1,4 @@
+# tflint-ignore-file: terraform_unused_declarations
 /**
  * Copyright 2025 Google LLC
  *


### PR DESCRIPTION
Fixes #956 

After merging, any repo maintainer should be able to click "Update Branch" on any open PR to resolve the linting issue related to this change. 