### PR TITLE
Align Terraform connector samples with UI defaults

### DIFF
--- a/managedkafka/managedkafka_create_connector_mirrormaker2_source/main.tf
+++ b/managedkafka/managedkafka_create_connector_mirrormaker2_source/main.tf
@@ -118,8 +118,8 @@ resource "google_managed_kafka_connector" "default" {
     "topics"               = ".*" # Replicate all topics from the source
     # The value for bootstrap.servers is a comma-separated list of hostname:port pairs
     # for one or more Kafka brokers in the source/target cluster.
-    "source.cluster.bootstrap.servers" = "source_cluster_dns"
-    "target.cluster.bootstrap.servers" = "target_cluster_dns"
+    "source.cluster.bootstrap.servers" = "bootstrap.${google_managed_kafka_cluster.source.cluster_id}.${google_managed_kafka_cluster.source.location}.managedkafka.${data.google_project.default.project_id}.cloud.goog:9092"
+    "target.cluster.bootstrap.servers" = "bootstrap.${google_managed_kafka_cluster.target.cluster_id}.${google_managed_kafka_cluster.target.location}.managedkafka.${data.google_project.default.project_id}.cloud.goog:9092"
     # You can define an exclusion policy for topics as follows:
     # To exclude internal MirrorMaker 2 topics, internal topics and replicated topics,.
     "topics.exclude" = "mm2.*\\.internal,.*\\.replica,__.*"

--- a/managedkafka/managedkafka_create_connector_mirrormaker2_source/main.tf
+++ b/managedkafka/managedkafka_create_connector_mirrormaker2_source/main.tf
@@ -76,7 +76,7 @@ resource "google_managed_kafka_connect_cluster" "default" {
         # "GMK_CLUSTER_ID.REGION.managedkafka.PROJECT_ID.cloud.goog.*"
         # Please note that we do NOT need to add the DNS name of the primary Kafka cluster to the
         # `dns_domain_names` list, as our Connect cluster configures that automatically.
-        dns_domain_names = ["DNS_DOMAIN_NAME"]
+        dns_domain_names = ["${google_managed_kafka_cluster.source.cluster_id}.${google_managed_kafka_cluster.source.location}.managedkafka.${data.google_project.default.project_id}.cloud.goog."]
       }
     }
   }

--- a/managedkafka/managedkafka_create_connector_pubsub_sink/main.tf
+++ b/managedkafka/managedkafka_create_connector_pubsub_sink/main.tf
@@ -85,8 +85,8 @@ resource "google_managed_kafka_connector" "example-pubsub-sink-connector" {
     "topics"          = "TOPIC_NAME"
     "cps.topic"       = "CPS_TOPIC_NAME"
     "cps.project"     = "CPS_PROJECT_NAME"
-    "value.converter" = "org.apache.kafka.connect.storage.StringConverter"
-    "key.converter"   = "org.apache.kafka.connect.storage.StringConverter"
+    "value.converter" = "org.apache.kafka.connect.converters.ByteArrayConverter"
+    "key.converter"   = "org.apache.kafka.connect.converters.ByteArrayConverter"
   }
 
   provider = google-beta

--- a/managedkafka/managedkafka_create_connector_pubsub_source/main.tf
+++ b/managedkafka/managedkafka_create_connector_pubsub_source/main.tf
@@ -79,14 +79,15 @@ resource "google_managed_kafka_connector" "example-pubsub-source-connector" {
   location        = "us-central1"
 
   configs = {
-    "connector.class"  = "com.google.pubsub.kafka.source.CloudPubSubSourceConnector"
-    "name"             = "my-pubsub-source-connector"
-    "tasks.max"        = "3"
-    "kafka.topic"      = "GMK_TOPIC_ID"
-    "cps.subscription" = "CPS_SUBSCRIPTION_ID"
-    "cps.project"      = data.google_project.default.project_id
-    "value.converter"  = "org.apache.kafka.connect.converters.ByteArrayConverter"
-    "key.converter"    = "org.apache.kafka.connect.storage.StringConverter"
+    "connector.class"          = "com.google.pubsub.kafka.source.CloudPubSubSourceConnector"
+    "name"                     = "my-pubsub-source-connector"
+    "tasks.max"                = "3"
+    "kafka.topic"              = "GMK_TOPIC_ID"
+    "cps.subscription"         = "CPS_SUBSCRIPTION_ID"
+    "cps.project"              = data.google_project.default.project_id
+    "cps.streamingPull.enable" = "true"
+    "value.converter"          = "org.apache.kafka.connect.converters.ByteArrayConverter"
+    "key.converter"            = "org.apache.kafka.connect.storage.StringConverter"
   }
 
   provider = google-beta


### PR DESCRIPTION
## Description

Fixes https://b.corp.google.com/issues/462154138/

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [x] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): https://cloud.google.com/managed-service-for-apache-kafka/docs/connect-cluster/create-connect-cluster#create-connect-cluster

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
