### PR TITLE
Add terraform docs on any-then-fail reservation affinity

### DIFF
--- a/gke/standard/zonal/reservation/main.tf
+++ b/gke/standard/zonal/reservation/main.tf
@@ -106,3 +106,56 @@ resource "google_container_node_pool" "specific_node_pool" {
   ]
 }
 # [END gke_standard_zonal_reservation_specific_node_pool]
+
+# [START gke_standard_zonal_reservation_any_then_fail_reservation]
+resource "google_compute_reservation" "any_then_fail_reservation" {
+  name = "any-then-fail-reservation"
+  zone = "us-central1-a"
+
+  specific_reservation {
+    count = 3
+
+    instance_properties {
+      machine_type = "e2-medium"
+    }
+  }
+}
+# [END gke_standard_zonal_reservation_any_then_fail_reservation]
+
+# [START gke_standard_zonal_reservation_any_then_fail_cluster]
+resource "google_container_cluster" "any_then_fail_cluster" {
+  name     = "gke-standard-zonal-any-then-fail-cluster"
+  location = "us-central1-a"
+
+  initial_node_count = 1
+
+  node_config {
+    machine_type = "e2-medium"
+
+    reservation_affinity {
+      consume_reservation_type = "ANY_RESERVATION_THEN_FAIL"
+    }
+  }
+
+  depends_on = [
+    google_compute_reservation.any_then_fail_reservation
+  ]
+}
+# [END gke_standard_zonal_reservation_any_then_fail_cluster]
+
+# [START gke_standard_zonal_reservation_any_then_fail_node_pool]
+resource "google_container_node_pool" "any_then_fail_node_pool" {
+  name     = "gke-any-then-fail-node-pool"
+  cluster  = google_container_cluster.any_then_fail_cluster.name
+  location = google_container_cluster.any_then_fail_cluster.location
+
+  initial_node_count = 3
+  node_config {
+    machine_type = "e2-medium"
+
+    reservation_affinity {
+      consume_reservation_type = "ANY_RESERVATION_THEN_FAIL"
+    }
+  }
+}
+# [END gke_standard_zonal_reservation_any_then_fail_node_pool]


### PR DESCRIPTION
## Description

Fixes # n/a

Note: If you are not associated with Google, open an issue for discussion before submitting a pull request.

## Checklist

**Readiness**

- [X] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [X] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s): https://clouddocs.devsite.corp.google.com/kubernetes-engine/docs/how-to/consuming-reservations#any-then-fail

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [ ] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [ ] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
