### PR TITLE
add examples for google_sql_provision_script resource

### DIFF
--- a/cloud_sql/mysql_provision_script_iam/main.tf
+++ b/cloud_sql/mysql_provision_script_iam/main.tf
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# [START cloud_sql_provision_script_instance]
+
+resource "google_sql_database_instance" "instance" {
+  name             = "my-instance"
+  database_version = "MYSQL_8_4"
+
+  settings {
+    tier            = "db-perf-optimized-N-2"
+    data_api_access = "ALLOW_DATA_API"
+    database_flags {
+      name  = "cloudsql_iam_authentication"
+      value = "on"
+    }
+  }
+  root_password = "changeme"
+}
+
+# [END cloud_sql_provision_script_instance]
+
+# [START cloud_sql_provision_script_iam_user]
+
+# Create a database user for your account and grant roles so it has privilege
+# to access the database. Choose an IAM type, e.g., "CLOUD_IAM_USER"
+# and "CLOUD_IAM_SERVICE_ACCOUNT".
+resource "google_sql_user" "iam_user" {
+  name     = "account-used-to-apply-this-config@example.com"
+  instance = google_sql_database_instance.instance.name
+  type     = "CLOUD_IAM_USER"
+
+  # Roles granted to the user. To follow the principle of least privilege, you
+  # can first use `google_sql_provision_script` to create custom database role(s)
+  # with lesser privileges and then assign them to this user in place of
+  # `cloudsqlsuperuser`.
+  # This field doesn't support MySQL 5.6 and 5.7. 
+  database_roles = ["cloudsqlsuperuser"]
+}
+
+# [END cloud_sql_provision_script_iam_user]
+
+# [START cloud_sql_provision_script_script]
+
+resource "google_sql_provision_script" "script" {
+  # You can inline the script or import from a file like
+  # `script  = file("${path.module}/script.sql")`
+  # When modified, the whole script will be executed again. It's recommended to
+  # make the script idempotent with patterns like `create if not exists ...` or
+  # `if not exists (select ...) then ... end if`. If it's not possible to make a
+  # statement idempotent, you can run it once and then remove it from the script.
+  script  = file("${path.module}/script.sql")
+
+  description = "sql script to create DBs and tables"
+  instance = google_sql_database_instance.instance.name
+
+  # Some of your queries may require a database. You can create and use a
+  # database inside the script, or explicitly reference a google_sql_database
+  # like `database = google_sql_database.database.name`.
+
+  # The identity account used to apply your Terraform config must exist as an
+  # IAM account in the instance. Terraform connects to the instance via IAM
+  # database authentication to execute the script.
+  depends_on = [google_sql_user.iam_user]
+}
+
+# [END cloud_sql_provision_script_script]

--- a/cloud_sql/mysql_provision_script_iam/main.tf
+++ b/cloud_sql/mysql_provision_script_iam/main.tf
@@ -60,6 +60,14 @@ resource "google_sql_database" "database" {
 
 # [START cloud_sql_provision_script_script]
 
+data "google_project" "project" {}
+
+resource "google_project_iam_member" "executesql_iam" {
+  project = data.google_project.project.id
+  role    = "roles/cloudsql.studioUser"
+  member  = "user:account-used-to-apply-this-config@example.com"
+}
+
 resource "google_sql_provision_script" "script" {
   script      = file("${path.module}/script.sql")
   description = "sql script to create DBs and tables"

--- a/cloud_sql/mysql_provision_script_iam/main.tf
+++ b/cloud_sql/mysql_provision_script_iam/main.tf
@@ -62,10 +62,10 @@ resource "google_sql_provision_script" "script" {
   # make the script idempotent with patterns like `create if not exists ...` or
   # `if not exists (select ...) then ... end if`. If it's not possible to make a
   # statement idempotent, you can run it once and then remove it from the script.
-  script  = file("${path.module}/script.sql")
+  script = file("${path.module}/script.sql")
 
   description = "sql script to create DBs and tables"
-  instance = google_sql_database_instance.instance.name
+  instance    = google_sql_database_instance.instance.name
 
   # Some of your queries may require a database. You can create and use a
   # database inside the script, or explicitly reference a google_sql_database

--- a/cloud_sql/mysql_provision_script_iam/main.tf
+++ b/cloud_sql/mysql_provision_script_iam/main.tf
@@ -16,9 +16,14 @@
 
 # [START cloud_sql_provision_script_instance]
 
+resource "random_password" "pwd" {
+  length = 16
+}
+
 resource "google_sql_database_instance" "instance" {
   name             = "my-instance"
   database_version = "MYSQL_8_4"
+  region           = "us-central1"
 
   settings {
     tier            = "db-perf-optimized-N-2"
@@ -28,53 +33,39 @@ resource "google_sql_database_instance" "instance" {
       value = "on"
     }
   }
-  root_password = "changeme"
+  root_password = random_password.pwd.result
 }
 
 # [END cloud_sql_provision_script_instance]
 
 # [START cloud_sql_provision_script_iam_user]
 
-# Create a database user for your account and grant roles so it has privilege
-# to access the database. Choose an IAM type, e.g., "CLOUD_IAM_USER"
-# and "CLOUD_IAM_SERVICE_ACCOUNT".
 resource "google_sql_user" "iam_user" {
   name     = "account-used-to-apply-this-config@example.com"
   instance = google_sql_database_instance.instance.name
   type     = "CLOUD_IAM_USER"
-
-  # Roles granted to the user. To follow the principle of least privilege, you
-  # can first use `google_sql_provision_script` to create custom database role(s)
-  # with lesser privileges and then assign them to this user in place of
-  # `cloudsqlsuperuser`.
-  # This field doesn't support MySQL 5.6 and 5.7. 
   database_roles = ["cloudsqlsuperuser"]
 }
 
 # [END cloud_sql_provision_script_iam_user]
 
+# [START cloud_sql_provision_script_database]
+
+resource "google_sql_database" "database" {
+  name     = "my-database"
+  instance = google_sql_database_instance.instance.name
+}
+
+# [END cloud_sql_provision_script_database]
+
 # [START cloud_sql_provision_script_script]
 
 resource "google_sql_provision_script" "script" {
-  # You can inline the script or import from a file like
-  # `script  = file("${path.module}/script.sql")`
-  # When modified, the whole script will be executed again. It's recommended to
-  # make the script idempotent with patterns like `create if not exists ...` or
-  # `if not exists (select ...) then ... end if`. If it's not possible to make a
-  # statement idempotent, you can run it once and then remove it from the script.
-  script = file("${path.module}/script.sql")
-
+  script      = file("${path.module}/script.sql")
   description = "sql script to create DBs and tables"
   instance    = google_sql_database_instance.instance.name
-
-  # Some of your queries may require a database. You can create and use a
-  # database inside the script, or explicitly reference a google_sql_database
-  # like `database = google_sql_database.database.name`.
-
-  # The identity account used to apply your Terraform config must exist as an
-  # IAM account in the instance. Terraform connects to the instance via IAM
-  # database authentication to execute the script.
-  depends_on = [google_sql_user.iam_user]
+  database    = google_sql_database.database.name
+  depends_on  = [google_sql_user.iam_user]
 }
 
 # [END cloud_sql_provision_script_script]

--- a/cloud_sql/mysql_provision_script_iam/test.yaml
+++ b/cloud_sql/mysql_provision_script_iam/test.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintTest
+metadata:
+  name: sql_mysql_provision_script_iam
+spec:
+  skip: true

--- a/cloud_sql/mysql_provision_script_secret_manager/main.tf
+++ b/cloud_sql/mysql_provision_script_secret_manager/main.tf
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# [START cloud_sql_provision_script_instance]
+
+resource "google_sql_database_instance" "instance" {
+  name             = "my-instance"
+  database_version = "MYSQL_8_4"
+
+  settings {
+    tier            = "db-perf-optimized-N-2"
+    data_api_access = "ALLOW_DATA_API"
+    database_flags {
+      name  = "cloudsql_iam_authentication"
+      value = "on"
+    }
+  }
+  root_password = "changeme"
+}
+
+# [END cloud_sql_provision_script_instance]
+
+# [START cloud_sql_provision_script_builtin_user]
+
+resource "google_sql_user" "built_in_user" {
+  name     = "tf-user"
+  host     = "%"
+  instance = google_sql_database_instance.instance.name
+  password = "changeme"
+  type     = "BUILT_IN"
+}
+
+# [END cloud_sql_provision_script_builtin_user]
+
+# [START cloud_sql_provision_script_secret]
+
+# Create a regional secret. Global secrets are not supported even if
+# located in one region only.
+resource "google_secret_manager_regional_secret" "secret" {
+  secret_id = "db-password"
+
+  # Use the same region as the Cloud SQL instance.
+  location = "us-central1"
+}
+
+# [END cloud_sql_provision_script_secret]
+
+# [START cloud_sql_provision_script_secret_version]
+
+resource "google_secret_manager_regional_secret_version" "secret_version" {
+  secret = google_secret_manager_regional_secret.secret.id
+  secret_data = "changeme"
+}
+
+# [END cloud_sql_provision_script_secret_version]
+
+# [START cloud_sql_provision_script_script]
+
+resource "google_sql_provision_script" "script" {
+  # You can inline the script or import from a file like
+  # `script  = file("${path.module}/script.sql")`
+  # When modified, the whole script will be executed again. It's recommended to
+  # make the script idempotent with patterns like `create if not exists ...` or
+  # `if not exists (select ...) then ... end if`. If it's not possible to make a
+  # statement idempotent, you can run it once and then remove it from the script.
+  script  = file("${path.module}/script.sql")
+
+  description = "sql script to create DBs and tables"
+  instance = google_sql_database_instance.instance.name
+
+  # Some of your queries may require a database. You can create and use a
+  # database inside the script, or explicitly reference a google_sql_database
+  # like `database = google_sql_database.database.name`.
+
+  user = google_sql_user.built_in_user.name
+
+  # The location should be the same as the Cloud SQL instance's location.
+  password_secret_version = "projects/my-project/locations/us-central1/secrets/db-password/versions/latest"
+
+  # The built-in database user and password secret version must be created
+  # first. Cloud SQL will retrieve password from Secret Manager
+  # and connect to this user account to execute your script.
+  depends_on = [
+    google_sql_user.built_in_user,
+    google_secret_manager_regional_secret_version.secret_version
+  ]
+}
+
+# [END cloud_sql_provision_script_script]

--- a/cloud_sql/mysql_provision_script_secret_manager/main.tf
+++ b/cloud_sql/mysql_provision_script_secret_manager/main.tf
@@ -61,7 +61,7 @@ resource "google_secret_manager_regional_secret" "secret" {
 # [START cloud_sql_provision_script_secret_version]
 
 resource "google_secret_manager_regional_secret_version" "secret_version" {
-  secret = google_secret_manager_regional_secret.secret.id
+  secret      = google_secret_manager_regional_secret.secret.id
   secret_data = "changeme"
 }
 
@@ -76,10 +76,10 @@ resource "google_sql_provision_script" "script" {
   # make the script idempotent with patterns like `create if not exists ...` or
   # `if not exists (select ...) then ... end if`. If it's not possible to make a
   # statement idempotent, you can run it once and then remove it from the script.
-  script  = file("${path.module}/script.sql")
+  script = file("${path.module}/script.sql")
 
   description = "sql script to create DBs and tables"
-  instance = google_sql_database_instance.instance.name
+  instance    = google_sql_database_instance.instance.name
 
   # Some of your queries may require a database. You can create and use a
   # database inside the script, or explicitly reference a google_sql_database

--- a/cloud_sql/mysql_provision_script_secret_manager/main.tf
+++ b/cloud_sql/mysql_provision_script_secret_manager/main.tf
@@ -87,6 +87,12 @@ resource "google_project_iam_member" "secret_accessor" {
 
 # [START cloud_sql_provision_script_script]
 
+resource "google_project_iam_member" "executesql_iam" {
+  project = data.google_project.project.id
+  role    = "roles/cloudsql.studioUser"
+  member  = "user:account-used-to-apply-this-config@example.com"
+}
+
 resource "google_sql_provision_script" "script" {
   script                  = file("${path.module}/script.sql")
   description             = "sql script to create DBs and tables"

--- a/cloud_sql/mysql_provision_script_secret_manager/main.tf
+++ b/cloud_sql/mysql_provision_script_secret_manager/main.tf
@@ -16,9 +16,14 @@
 
 # [START cloud_sql_provision_script_instance]
 
+resource "random_password" "pwd" {
+  length = 16
+}
+
 resource "google_sql_database_instance" "instance" {
   name             = "my-instance"
   database_version = "MYSQL_8_4"
+  region           = "us-central1"
 
   settings {
     tier            = "db-perf-optimized-N-2"
@@ -28,71 +33,68 @@ resource "google_sql_database_instance" "instance" {
       value = "on"
     }
   }
-  root_password = "changeme"
+  root_password = random_password.pwd.result
 }
 
 # [END cloud_sql_provision_script_instance]
 
 # [START cloud_sql_provision_script_builtin_user]
 
+resource "random_password" "user_pwd" {
+  length = 16
+}
+
 resource "google_sql_user" "built_in_user" {
   name     = "tf-user"
   host     = "%"
   instance = google_sql_database_instance.instance.name
-  password = "changeme"
+  password = random_password.user_pwd.result
   type     = "BUILT_IN"
 }
 
 # [END cloud_sql_provision_script_builtin_user]
 
+# [START cloud_sql_provision_script_database]
+
+resource "google_sql_database" "database" {
+  name     = "my-database"
+  instance = google_sql_database_instance.instance.name
+}
+
+# [END cloud_sql_provision_script_database]
+
 # [START cloud_sql_provision_script_secret]
 
-# Create a regional secret. Global secrets are not supported even if
-# located in one region only.
 resource "google_secret_manager_regional_secret" "secret" {
   secret_id = "db-password"
+  location  = "us-central1"
+}
 
-  # Use the same region as the Cloud SQL instance.
-  location = "us-central1"
+resource "google_secret_manager_regional_secret_version" "secret_version" {
+  secret      = google_secret_manager_regional_secret.secret.id
+  secret_data = random_password.user_pwd.result
+}
+
+data "google_project" "project" {}
+
+resource "google_project_iam_member" "secret_accessor" {
+  project = data.google_project.project.id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "user:account-used-to-apply-this-config@example.com"
 }
 
 # [END cloud_sql_provision_script_secret]
 
-# [START cloud_sql_provision_script_secret_version]
-
-resource "google_secret_manager_regional_secret_version" "secret_version" {
-  secret      = google_secret_manager_regional_secret.secret.id
-  secret_data = "changeme"
-}
-
-# [END cloud_sql_provision_script_secret_version]
-
 # [START cloud_sql_provision_script_script]
 
 resource "google_sql_provision_script" "script" {
-  # You can inline the script or import from a file like
-  # `script  = file("${path.module}/script.sql")`
-  # When modified, the whole script will be executed again. It's recommended to
-  # make the script idempotent with patterns like `create if not exists ...` or
-  # `if not exists (select ...) then ... end if`. If it's not possible to make a
-  # statement idempotent, you can run it once and then remove it from the script.
-  script = file("${path.module}/script.sql")
+  script                  = file("${path.module}/script.sql")
+  description             = "sql script to create DBs and tables"
+  instance                = google_sql_database_instance.instance.name
+  database                = google_sql_database.database.name
+  user                    = google_sql_user.built_in_user.name
+  password_secret_version = "projects/${data.google_project.project.id}/locations/us-central1/secrets/db-password/versions/latest"
 
-  description = "sql script to create DBs and tables"
-  instance    = google_sql_database_instance.instance.name
-
-  # Some of your queries may require a database. You can create and use a
-  # database inside the script, or explicitly reference a google_sql_database
-  # like `database = google_sql_database.database.name`.
-
-  user = google_sql_user.built_in_user.name
-
-  # The location should be the same as the Cloud SQL instance's location.
-  password_secret_version = "projects/my-project/locations/us-central1/secrets/db-password/versions/latest"
-
-  # The built-in database user and password secret version must be created
-  # first. Cloud SQL will retrieve password from Secret Manager
-  # and connect to this user account to execute your script.
   depends_on = [
     google_sql_user.built_in_user,
     google_secret_manager_regional_secret_version.secret_version

--- a/cloud_sql/mysql_provision_script_secret_manager/test.yaml
+++ b/cloud_sql/mysql_provision_script_secret_manager/test.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintTest
+metadata:
+  name: sql_mysql_provision_script_secret_manager
+spec:
+  skip: true

--- a/cloud_sql/postgres_provision_script_iam/main.tf
+++ b/cloud_sql/postgres_provision_script_iam/main.tf
@@ -16,9 +16,14 @@
 
 # [START cloud_sql_provision_script_instance]
 
+resource "random_password" "pwd" {
+  length = 16
+}
+
 resource "google_sql_database_instance" "instance" {
   name             = "my-instance"
   database_version = "POSTGRES_17"
+  region           = "us-central1"
 
   settings {
     tier            = "db-perf-optimized-N-2"
@@ -28,27 +33,17 @@ resource "google_sql_database_instance" "instance" {
       value = "on"
     }
   }
-  root_password = "changeme"
+  root_password = random_password.pwd.result
 }
 
 # [END cloud_sql_provision_script_instance]
 
 # [START cloud_sql_provision_script_iam_user]
 
-# Create a database user for your account and grant roles so it has privilege
-# to access the database. Choose an IAM type, e.g., "CLOUD_IAM_USER"
-# and "CLOUD_IAM_SERVICE_ACCOUNT". If a service account is used and the
-# instance is Postgres, please trim the ".gserviceaccount.com" suffix to
-# avoid exceeding the username length limit.
 resource "google_sql_user" "iam_user" {
   name     = "account-used-to-apply-this-config@example.com"
   instance = google_sql_database_instance.instance.name
-  type     = "CLOUD_IAM_USER"
-
-  # Roles granted to the user. To follow the principle of least privilege, you
-  # can first use `google_sql_provision_script` to create custom database role(s)
-  # with lesser privileges and then assign them to this user in place of
-  # `cloudsqlsuperuser`.
+  type     = "CLOUD_IAM_USER" 
   database_roles = ["cloudsqlsuperuser"]
 }
 
@@ -66,21 +61,11 @@ resource "google_sql_database" "database" {
 # [START cloud_sql_provision_script_script]
 
 resource "google_sql_provision_script" "table" {
-  # You can inline the script or import from a file like
-  # `script  = file("${path.module}/script.sql")`
-  # When modified, the whole script will be executed again. It's recommended to
-  # make the script idempotent with patterns like `create if not exists ...` or
-  # `if not exists (select ...) then ... end if`. If it's not possible to make a
-  # statement idempotent, you can run it once and then remove it from the script.
-  script = "CREATE TABLE IF NOT EXISTS table1 ( col VARCHAR(16) NOT NULL );"
-
+  script      = "CREATE TABLE IF NOT EXISTS table1 ( col VARCHAR(16) NOT NULL );"
   instance    = google_sql_database_instance.instance.name
   database    = google_sql_database.database.name
   description = "sql script to create tables"
 
-  # The identity account used to apply your Terraform config must exist as an
-  # IAM account in the instance. Terraform connects to the instance via IAM
-  # database authentication to execute the script.
   depends_on = [google_sql_user.iam_user]
 }
 

--- a/cloud_sql/postgres_provision_script_iam/main.tf
+++ b/cloud_sql/postgres_provision_script_iam/main.tf
@@ -60,6 +60,14 @@ resource "google_sql_database" "database" {
 
 # [START cloud_sql_provision_script_script]
 
+data "google_project" "project" {}
+
+resource "google_project_iam_member" "executesql_iam" {
+  project = data.google_project.project.id
+  role    = "roles/cloudsql.studioUser"
+  member  = "user:account-used-to-apply-this-config@example.com"
+}
+
 resource "google_sql_provision_script" "table" {
   script      = "CREATE TABLE IF NOT EXISTS table1 ( col VARCHAR(16) NOT NULL );"
   instance    = google_sql_database_instance.instance.name

--- a/cloud_sql/postgres_provision_script_iam/main.tf
+++ b/cloud_sql/postgres_provision_script_iam/main.tf
@@ -72,10 +72,10 @@ resource "google_sql_provision_script" "table" {
   # make the script idempotent with patterns like `create if not exists ...` or
   # `if not exists (select ...) then ... end if`. If it's not possible to make a
   # statement idempotent, you can run it once and then remove it from the script.
-  script  = "CREATE TABLE IF NOT EXISTS table1 ( col VARCHAR(16) NOT NULL );"
+  script = "CREATE TABLE IF NOT EXISTS table1 ( col VARCHAR(16) NOT NULL );"
 
-  instance = google_sql_database_instance.instance.name
-  database = google_sql_database.database.name
+  instance    = google_sql_database_instance.instance.name
+  database    = google_sql_database.database.name
   description = "sql script to create tables"
 
   # The identity account used to apply your Terraform config must exist as an

--- a/cloud_sql/postgres_provision_script_iam/main.tf
+++ b/cloud_sql/postgres_provision_script_iam/main.tf
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# [START cloud_sql_provision_script_instance]
+
+resource "google_sql_database_instance" "instance" {
+  name             = "my-instance"
+  database_version = "POSTGRES_17"
+
+  settings {
+    tier            = "db-perf-optimized-N-2"
+    data_api_access = "ALLOW_DATA_API"
+    database_flags {
+      name  = "cloudsql.iam_authentication"
+      value = "on"
+    }
+  }
+  root_password = "changeme"
+}
+
+# [END cloud_sql_provision_script_instance]
+
+# [START cloud_sql_provision_script_iam_user]
+
+# Create a database user for your account and grant roles so it has privilege
+# to access the database. Choose an IAM type, e.g., "CLOUD_IAM_USER"
+# and "CLOUD_IAM_SERVICE_ACCOUNT". If a service account is used and the
+# instance is Postgres, please trim the ".gserviceaccount.com" suffix to
+# avoid exceeding the username length limit.
+resource "google_sql_user" "iam_user" {
+  name     = "account-used-to-apply-this-config@example.com"
+  instance = google_sql_database_instance.instance.name
+  type     = "CLOUD_IAM_USER"
+
+  # Roles granted to the user. To follow the principle of least privilege, you
+  # can first use `google_sql_provision_script` to create custom database role(s)
+  # with lesser privileges and then assign them to this user in place of
+  # `cloudsqlsuperuser`.
+  database_roles = ["cloudsqlsuperuser"]
+}
+
+# [END cloud_sql_provision_script_iam_user]
+
+# [START cloud_sql_provision_script_database]
+
+resource "google_sql_database" "database" {
+  name     = "my-database"
+  instance = google_sql_database_instance.instance.name
+}
+
+# [END cloud_sql_provision_script_database]
+
+# [START cloud_sql_provision_script_script]
+
+resource "google_sql_provision_script" "table" {
+  # You can inline the script or import from a file like
+  # `script  = file("${path.module}/script.sql")`
+  # When modified, the whole script will be executed again. It's recommended to
+  # make the script idempotent with patterns like `create if not exists ...` or
+  # `if not exists (select ...) then ... end if`. If it's not possible to make a
+  # statement idempotent, you can run it once and then remove it from the script.
+  script  = "CREATE TABLE IF NOT EXISTS table1 ( col VARCHAR(16) NOT NULL );"
+
+  instance = google_sql_database_instance.instance.name
+  database = google_sql_database.database.name
+  description = "sql script to create tables"
+
+  # The identity account used to apply your Terraform config must exist as an
+  # IAM account in the instance. Terraform connects to the instance via IAM
+  # database authentication to execute the script.
+  depends_on = [google_sql_user.iam_user]
+}
+
+# [END cloud_sql_provision_script_script]

--- a/cloud_sql/postgres_provision_script_iam/test.yaml
+++ b/cloud_sql/postgres_provision_script_iam/test.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintTest
+metadata:
+  name: sql_postgres_provision_script_iam
+spec:
+  skip: true

--- a/cloud_sql/postgres_provision_script_secret_manager/main.tf
+++ b/cloud_sql/postgres_provision_script_secret_manager/main.tf
@@ -86,6 +86,12 @@ resource "google_sql_database" "database" {
 
 # [START cloud_sql_provision_script_script]
 
+resource "google_project_iam_member" "executesql_iam" {
+  project = data.google_project.project.id
+  role    = "roles/cloudsql.studioUser"
+  member  = "user:account-used-to-apply-this-config@example.com"
+}
+
 resource "google_sql_provision_script" "table" {
   script                  = "CREATE TABLE IF NOT EXISTS table1 ( col VARCHAR(16) NOT NULL );"
   instance                = google_sql_database_instance.instance.name

--- a/cloud_sql/postgres_provision_script_secret_manager/main.tf
+++ b/cloud_sql/postgres_provision_script_secret_manager/main.tf
@@ -60,7 +60,7 @@ resource "google_secret_manager_regional_secret" "secret" {
 # [START cloud_sql_provision_script_secret_version]
 
 resource "google_secret_manager_regional_secret_version" "secret_version" {
-  secret = google_secret_manager_regional_secret.secret.id
+  secret      = google_secret_manager_regional_secret.secret.id
   secret_data = "changeme"
 }
 
@@ -84,12 +84,12 @@ resource "google_sql_provision_script" "table" {
   # make the script idempotent with patterns like `create if not exists ...` or
   # `if not exists (select ...) then ... end if`. If it's not possible to make a
   # statement idempotent, you can run it once and then remove it from the script.
-  script  = "CREATE TABLE IF NOT EXISTS table1 ( col VARCHAR(16) NOT NULL );"
+  script = "CREATE TABLE IF NOT EXISTS table1 ( col VARCHAR(16) NOT NULL );"
 
-  instance = google_sql_database_instance.instance.name
-  database = google_sql_database.database.name
+  instance    = google_sql_database_instance.instance.name
+  database    = google_sql_database.database.name
   description = "sql script to create tables"
-  user = google_sql_user.built_in_user.name
+  user        = google_sql_user.built_in_user.name
 
   # The location should be the same as the Cloud SQL instance's location.
   password_secret_version = "projects/my-project/locations/us-central1/secrets/db-password/versions/latest"

--- a/cloud_sql/postgres_provision_script_secret_manager/main.tf
+++ b/cloud_sql/postgres_provision_script_secret_manager/main.tf
@@ -16,9 +16,14 @@
 
 # [START cloud_sql_provision_script_instance]
 
+resource "random_password" "pwd" {
+  length = 16
+}
+
 resource "google_sql_database_instance" "instance" {
   name             = "my-instance"
   database_version = "POSTGRES_17"
+  region           = "us-central1"
 
   settings {
     tier            = "db-perf-optimized-N-2"
@@ -28,17 +33,21 @@ resource "google_sql_database_instance" "instance" {
       value = "on"
     }
   }
-  root_password = "changeme"
+  root_password = random_password.pwd.result
 }
 
 # [END cloud_sql_provision_script_instance]
 
 # [START cloud_sql_provision_script_builtin_user]
 
+resource "random_password" "user_pwd" {
+  length = 16
+}
+
 resource "google_sql_user" "built_in_user" {
   name     = "tf-user"
   instance = google_sql_database_instance.instance.name
-  password = "changeme"
+  password = random_password.user_pwd.result
   type     = "BUILT_IN"
 }
 
@@ -46,25 +55,25 @@ resource "google_sql_user" "built_in_user" {
 
 # [START cloud_sql_provision_script_secret]
 
-# Create a regional secret. Global secrets are not supported even if
-# located in one region only.
 resource "google_secret_manager_regional_secret" "secret" {
   secret_id = "db-password"
-
-  # Use the same region as the Cloud SQL instance.
-  location = "us-central1"
+  location  = "us-central1"
 }
-
-# [END cloud_sql_provision_script_secret]
-
-# [START cloud_sql_provision_script_secret_version]
 
 resource "google_secret_manager_regional_secret_version" "secret_version" {
   secret      = google_secret_manager_regional_secret.secret.id
-  secret_data = "changeme"
+  secret_data = random_password.user_pwd.result
 }
 
-# [END cloud_sql_provision_script_secret_version]
+data "google_project" "project" {}
+
+resource "google_project_iam_member" "secret_accessor" {
+  project = data.google_project.project.id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "user:account-used-to-apply-this-config@example.com"
+}
+
+# [END cloud_sql_provision_script_secret]
 
 # [START cloud_sql_provision_script_database]
 
@@ -78,25 +87,13 @@ resource "google_sql_database" "database" {
 # [START cloud_sql_provision_script_script]
 
 resource "google_sql_provision_script" "table" {
-  # You can inline the script or import from a file like
-  # `script  = file("${path.module}/script.sql")`
-  # When modified, the whole script will be executed again. It's recommended to
-  # make the script idempotent with patterns like `create if not exists ...` or
-  # `if not exists (select ...) then ... end if`. If it's not possible to make a
-  # statement idempotent, you can run it once and then remove it from the script.
-  script = "CREATE TABLE IF NOT EXISTS table1 ( col VARCHAR(16) NOT NULL );"
+  script                  = "CREATE TABLE IF NOT EXISTS table1 ( col VARCHAR(16) NOT NULL );"
+  instance                = google_sql_database_instance.instance.name
+  database                = google_sql_database.database.name
+  description             = "sql script to create tables"
+  user                    = google_sql_user.built_in_user.name
+  password_secret_version = "projects/${data.google_project.project.id}/locations/us-central1/secrets/db-password/versions/latest"
 
-  instance    = google_sql_database_instance.instance.name
-  database    = google_sql_database.database.name
-  description = "sql script to create tables"
-  user        = google_sql_user.built_in_user.name
-
-  # The location should be the same as the Cloud SQL instance's location.
-  password_secret_version = "projects/my-project/locations/us-central1/secrets/db-password/versions/latest"
-
-  # The built-in database user and password secret version must be created
-  # first. Cloud SQL will retrieve password from Secret Manager
-  # and connect to this user account to execute your script.
   depends_on = [
     google_sql_user.built_in_user,
     google_secret_manager_regional_secret_version.secret_version

--- a/cloud_sql/postgres_provision_script_secret_manager/main.tf
+++ b/cloud_sql/postgres_provision_script_secret_manager/main.tf
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# [START cloud_sql_provision_script_instance]
+
+resource "google_sql_database_instance" "instance" {
+  name             = "my-instance"
+  database_version = "POSTGRES_17"
+
+  settings {
+    tier            = "db-perf-optimized-N-2"
+    data_api_access = "ALLOW_DATA_API"
+    database_flags {
+      name  = "cloudsql.iam_authentication"
+      value = "on"
+    }
+  }
+  root_password = "changeme"
+}
+
+# [END cloud_sql_provision_script_instance]
+
+# [START cloud_sql_provision_script_builtin_user]
+
+resource "google_sql_user" "built_in_user" {
+  name     = "tf-user"
+  instance = google_sql_database_instance.instance.name
+  password = "changeme"
+  type     = "BUILT_IN"
+}
+
+# [END cloud_sql_provision_script_builtin_user]
+
+# [START cloud_sql_provision_script_secret]
+
+# Create a regional secret. Global secrets are not supported even if
+# located in one region only.
+resource "google_secret_manager_regional_secret" "secret" {
+  secret_id = "db-password"
+
+  # Use the same region as the Cloud SQL instance.
+  location = "us-central1"
+}
+
+# [END cloud_sql_provision_script_secret]
+
+# [START cloud_sql_provision_script_secret_version]
+
+resource "google_secret_manager_regional_secret_version" "secret_version" {
+  secret = google_secret_manager_regional_secret.secret.id
+  secret_data = "changeme"
+}
+
+# [END cloud_sql_provision_script_secret_version]
+
+# [START cloud_sql_provision_script_database]
+
+resource "google_sql_database" "database" {
+  name     = "my-database"
+  instance = google_sql_database_instance.instance.name
+}
+
+# [END cloud_sql_provision_script_database]
+
+# [START cloud_sql_provision_script_script]
+
+resource "google_sql_provision_script" "table" {
+  # You can inline the script or import from a file like
+  # `script  = file("${path.module}/script.sql")`
+  # When modified, the whole script will be executed again. It's recommended to
+  # make the script idempotent with patterns like `create if not exists ...` or
+  # `if not exists (select ...) then ... end if`. If it's not possible to make a
+  # statement idempotent, you can run it once and then remove it from the script.
+  script  = "CREATE TABLE IF NOT EXISTS table1 ( col VARCHAR(16) NOT NULL );"
+
+  instance = google_sql_database_instance.instance.name
+  database = google_sql_database.database.name
+  description = "sql script to create tables"
+  user = google_sql_user.built_in_user.name
+
+  # The location should be the same as the Cloud SQL instance's location.
+  password_secret_version = "projects/my-project/locations/us-central1/secrets/db-password/versions/latest"
+
+  # The built-in database user and password secret version must be created
+  # first. Cloud SQL will retrieve password from Secret Manager
+  # and connect to this user account to execute your script.
+  depends_on = [
+    google_sql_user.built_in_user,
+    google_secret_manager_regional_secret_version.secret_version
+  ]
+}
+
+# [END cloud_sql_provision_script_script]

--- a/cloud_sql/postgres_provision_script_secret_manager/test.yaml
+++ b/cloud_sql/postgres_provision_script_secret_manager/test.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintTest
+metadata:
+  name: sql_postgres_provision_script_secret_manager
+spec:
+  skip: true

--- a/cloud_sql/sqlserver_provision_script_secret_manager/main.tf
+++ b/cloud_sql/sqlserver_provision_script_secret_manager/main.tf
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# [START cloud_sql_provision_script_instance]
+
+resource "google_sql_database_instance" "instance" {
+  name             = "my-instance"
+  database_version = "SQLSERVER_2025_ENTERPRISE"
+
+  settings {
+    tier            = "db-perf-optimized-N-2"
+    data_api_access = "ALLOW_DATA_API"
+  }
+  root_password = "changeme"
+}
+
+# [END cloud_sql_provision_script_instance]
+
+# [START cloud_sql_provision_script_builtin_user]
+
+resource "google_sql_user" "built_in_user" {
+  name     = "tf-user"
+  instance = google_sql_database_instance.instance.name
+  password = "changeme"
+  type     = "BUILT_IN"
+}
+
+# [END cloud_sql_provision_script_builtin_user]
+
+# [START cloud_sql_provision_script_secret]
+
+# Create a regional secret. Global secrets are not supported even if
+# located in one region only.
+resource "google_secret_manager_regional_secret" "secret" {
+  secret_id = "db-password"
+
+  # Use the same region as the Cloud SQL instance.
+  location = "us-central1"
+}
+
+# [END cloud_sql_provision_script_secret]
+
+# [START cloud_sql_provision_script_secret_version]
+
+resource "google_secret_manager_regional_secret_version" "secret_version" {
+  secret = google_secret_manager_regional_secret.secret.id
+  secret_data = "changeme"
+}
+
+# [END cloud_sql_provision_script_secret_version]
+
+# [START cloud_sql_provision_script_database]
+
+resource "google_sql_database" "database" {
+  name     = "my-database"
+  instance = google_sql_database_instance.instance.name
+}
+
+# [END cloud_sql_provision_script_database]
+
+# [START cloud_sql_provision_script_script]
+
+resource "google_sql_provision_script" "script" {
+  # You can inline the script or import from a file like
+  # `script  = file("${path.module}/script.sql")`
+  # When modified, the whole script will be executed again. It's recommended to
+  # make the script idempotent with patterns like `create if not exists ...` or
+  # `if not exists (select ...) then ... end if`. If it's not possible to make a
+  # statement idempotent, you can run it once and then remove it from the script.
+  script  = file("${path.module}/script.sql")
+
+  instance = google_sql_database_instance.instance.name
+  database = google_sql_database.database.name
+  description = "sql script to create tables, create roles, and grant privileges"
+  user = google_sql_user.built_in_user.name
+
+  # The location should be the same as the Cloud SQL instance's location.
+  password_secret_version = "projects/my-project/locations/us-central1/secrets/db-password/versions/latest"
+
+  # The built-in database user and password secret version must be created
+  # first. Cloud SQL will retrieve password from Secret Manager
+  # and connect to this user account to execute your script.
+  depends_on = [
+    google_sql_user.built_in_user,
+    google_secret_manager_regional_secret_version.secret_version
+  ]
+}
+
+# [END cloud_sql_provision_script_script]

--- a/cloud_sql/sqlserver_provision_script_secret_manager/main.tf
+++ b/cloud_sql/sqlserver_provision_script_secret_manager/main.tf
@@ -16,51 +16,45 @@
 
 # [START cloud_sql_provision_script_instance]
 
+resource "random_password" "pwd" {
+  length = 16
+}
+
 resource "google_sql_database_instance" "instance" {
   name             = "my-instance"
   database_version = "SQLSERVER_2025_ENTERPRISE"
+  region           = "us-central1"
 
   settings {
     tier            = "db-perf-optimized-N-2"
     data_api_access = "ALLOW_DATA_API"
   }
-  root_password = "changeme"
+  root_password = random_password.pwd.result
 }
 
 # [END cloud_sql_provision_script_instance]
 
-# [START cloud_sql_provision_script_builtin_user]
-
-resource "google_sql_user" "built_in_user" {
-  name     = "tf-user"
-  instance = google_sql_database_instance.instance.name
-  password = "changeme"
-  type     = "BUILT_IN"
-}
-
-# [END cloud_sql_provision_script_builtin_user]
-
 # [START cloud_sql_provision_script_secret]
 
-# Create a regional secret. Global secrets are not supported even if
-# located in one region only.
 resource "google_secret_manager_regional_secret" "secret" {
   secret_id = "db-password"
-
-  # Use the same region as the Cloud SQL instance.
-  location = "us-central1"
+  location  = "us-central1"
 }
-
-# [END cloud_sql_provision_script_secret]
-
-# [START cloud_sql_provision_script_secret_version]
 
 resource "google_secret_manager_regional_secret_version" "secret_version" {
   secret      = google_secret_manager_regional_secret.secret.id
-  secret_data = "changeme"
+  secret_data = random_password.pwd.result
 }
 
-# [END cloud_sql_provision_script_secret_version]
+data "google_project" "project" {}
+
+resource "google_project_iam_member" "secret_accessor" {
+  project = data.google_project.project.id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "user:account-used-to-apply-this-config@example.com"
+}
+
+# [END cloud_sql_provision_script_secret]
 
 # [START cloud_sql_provision_script_database]
 
@@ -74,25 +68,13 @@ resource "google_sql_database" "database" {
 # [START cloud_sql_provision_script_script]
 
 resource "google_sql_provision_script" "script" {
-  # You can inline the script or import from a file like
-  # `script  = file("${path.module}/script.sql")`
-  # When modified, the whole script will be executed again. It's recommended to
-  # make the script idempotent with patterns like `create if not exists ...` or
-  # `if not exists (select ...) then ... end if`. If it's not possible to make a
-  # statement idempotent, you can run it once and then remove it from the script.
-  script = file("${path.module}/script.sql")
+  script                  = file("${path.module}/script.sql")
+  instance                = google_sql_database_instance.instance.name
+  database                = google_sql_database.database.name
+  description             = "sql script to create tables, create roles, and grant privileges"
+  user                    = 'sqlserver'
+  password_secret_version = "projects/${data.google_project.project.id}/locations/us-central1/secrets/db-password/versions/latest"
 
-  instance    = google_sql_database_instance.instance.name
-  database    = google_sql_database.database.name
-  description = "sql script to create tables, create roles, and grant privileges"
-  user        = google_sql_user.built_in_user.name
-
-  # The location should be the same as the Cloud SQL instance's location.
-  password_secret_version = "projects/my-project/locations/us-central1/secrets/db-password/versions/latest"
-
-  # The built-in database user and password secret version must be created
-  # first. Cloud SQL will retrieve password from Secret Manager
-  # and connect to this user account to execute your script.
   depends_on = [
     google_sql_user.built_in_user,
     google_secret_manager_regional_secret_version.secret_version

--- a/cloud_sql/sqlserver_provision_script_secret_manager/main.tf
+++ b/cloud_sql/sqlserver_provision_script_secret_manager/main.tf
@@ -67,6 +67,12 @@ resource "google_sql_database" "database" {
 
 # [START cloud_sql_provision_script_script]
 
+resource "google_project_iam_member" "executesql_iam" {
+  project = data.google_project.project.id
+  role    = "roles/cloudsql.studioUser"
+  member  = "user:account-used-to-apply-this-config@example.com"
+}
+
 resource "google_sql_provision_script" "script" {
   script                  = file("${path.module}/script.sql")
   instance                = google_sql_database_instance.instance.name

--- a/cloud_sql/sqlserver_provision_script_secret_manager/main.tf
+++ b/cloud_sql/sqlserver_provision_script_secret_manager/main.tf
@@ -56,7 +56,7 @@ resource "google_secret_manager_regional_secret" "secret" {
 # [START cloud_sql_provision_script_secret_version]
 
 resource "google_secret_manager_regional_secret_version" "secret_version" {
-  secret = google_secret_manager_regional_secret.secret.id
+  secret      = google_secret_manager_regional_secret.secret.id
   secret_data = "changeme"
 }
 
@@ -80,12 +80,12 @@ resource "google_sql_provision_script" "script" {
   # make the script idempotent with patterns like `create if not exists ...` or
   # `if not exists (select ...) then ... end if`. If it's not possible to make a
   # statement idempotent, you can run it once and then remove it from the script.
-  script  = file("${path.module}/script.sql")
+  script = file("${path.module}/script.sql")
 
-  instance = google_sql_database_instance.instance.name
-  database = google_sql_database.database.name
+  instance    = google_sql_database_instance.instance.name
+  database    = google_sql_database.database.name
   description = "sql script to create tables, create roles, and grant privileges"
-  user = google_sql_user.built_in_user.name
+  user        = google_sql_user.built_in_user.name
 
   # The location should be the same as the Cloud SQL instance's location.
   password_secret_version = "projects/my-project/locations/us-central1/secrets/db-password/versions/latest"

--- a/cloud_sql/sqlserver_provision_script_secret_manager/test.yaml
+++ b/cloud_sql/sqlserver_provision_script_secret_manager/test.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintTest
+metadata:
+  name: sql_sqlserver_provision_script_secret_manager
+spec:
+  skip: true


### PR DESCRIPTION
## Description

Add examples for `google_sql_provision_script` resource

## Checklist

**Readiness**

- [x] Yes, **merge** this PR after it is approved
- [ ] No, don't **merge** this PR after it is approved

**Style**

- [x] My sample follows the rules described for Terraform in the [Effective Samples style guide](https://googlecloudplatform.github.io/samples-style-guide/)
- [ ] My sample follows the other requirements and best practices in the [Contributing
guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#other-requirements-and-best-practices)

**Testing**

- [x] I have performed tests described in the [Contributing guide](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md):

   - [x] **[Tests](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#set-up-the-test-environment)** pass: `terraform apply`
   - [x] **[Lint](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/CONTRIBUTING.md#linting-and-formatting)** pass: `terraform fmt` check

**Intended location**

- [x] Yes, this sample will be (or already is) included on cloud.google.com
      Location(s):

- [ ] No, this sample won't be included on cloud.google.com
      Reason:

**API enablement**

- [x] If the sample needs an API enabled to pass testing, I have added the service to the [Test setup file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/test/setup/main.tf)

**Review**

- [x] If this sample adds a new directory, I have added codeowners to the [CODEOWNERS file](https://github.com/terraform-google-modules/terraform-docs-samples/blob/main/.github/CODEOWNERS)
